### PR TITLE
More SNI probes

### DIFF
--- a/prober.py
+++ b/prober.py
@@ -49,6 +49,7 @@ probes = [
     SNIWithDifferentType(),
     SNIDifferentTypeRev(),
     SNIOverflow(),
+    SNIUnderflow(),
     SecureRenegoOverflow(),
     SecureRenegoUnderflow(),
     SecureRenegoNonEmpty(),

--- a/prober.py
+++ b/prober.py
@@ -45,6 +45,7 @@ probes = [
     SNIWrongName(),
     SNILongName(),
     SNIEmptyName(),
+    SNIOneWrong(),
     SecureRenegoOverflow(),
     SecureRenegoUnderflow(),
     SecureRenegoNonEmpty(),

--- a/prober.py
+++ b/prober.py
@@ -48,6 +48,7 @@ probes = [
     SNIOneWrong(),
     SNIWithDifferentType(),
     SNIDifferentTypeRev(),
+    SNIOverflow(),
     SecureRenegoOverflow(),
     SecureRenegoUnderflow(),
     SecureRenegoNonEmpty(),

--- a/prober.py
+++ b/prober.py
@@ -47,6 +47,7 @@ probes = [
     SNIEmptyName(),
     SNIOneWrong(),
     SNIWithDifferentType(),
+    SNIDifferentTypeRev(),
     SecureRenegoOverflow(),
     SecureRenegoUnderflow(),
     SecureRenegoNonEmpty(),

--- a/prober.py
+++ b/prober.py
@@ -46,6 +46,7 @@ probes = [
     SNILongName(),
     SNIEmptyName(),
     SNIOneWrong(),
+    SNIWithDifferentType(),
     SecureRenegoOverflow(),
     SecureRenegoUnderflow(),
     SecureRenegoNonEmpty(),

--- a/probes.py
+++ b/probes.py
@@ -670,6 +670,19 @@ class SNIWithDifferentType(Probe):
         sock.write(self.make_sni_hello(server_names))
 
 
+class SNIDifferentTypeRev(SNIWithDifferentType):
+    '''Send hello like in SNIWithDifferentType but reverse order of names'''
+
+    def test(self, sock):
+        logging.debug('Sending Client Hello...')
+        server_names = []
+        # only type 0 (HostName) is defined, any other should be ignored
+        server_names += [(4, '<binary-data>')]
+        server_names += [(ServerNameExtension.HostName, self.ipaddress)]
+
+        sock.write(self.make_sni_hello(server_names))
+
+
 class SecureRenegoOverflow(Probe):
     '''Send secure renegotiation with data length exceeding stated size'''
 

--- a/probes.py
+++ b/probes.py
@@ -709,6 +709,31 @@ class SNIOverflow(Probe):
         sock.write(self.make_sni_hello(self.ipaddress))
 
 
+class SNIUnderflow(Probe):
+    '''Send server name indication with data length smaller than size inside'''
+
+    def make_sni_hello(self, name):
+        sni_extension = ServerNameExtension.create(name)
+        # first four bytes are the header
+        ext_data = sni_extension.bytes[4:] + '\x00\x00\x00'
+        sni_extension = Extension.create(extension_type=Extension.ServerName,
+                                         data=ext_data)
+
+        hello = ClientHelloMessage.create(TLSRecord.TLS1_0,
+                                          '01234567890123456789012345678901',
+                                          DEFAULT_CIPHERS,
+                                          extensions=[sni_extension])
+
+        record = TLSRecord.create(content_type=TLSRecord.Handshake,
+                                  version=TLSRecord.TLS1_0,
+                                  message=hello.bytes)
+
+        return record.bytes
+
+    def test(self, sock):
+        logging.debug('Sending Client Hello...')
+        sock.write(self.make_sni_hello(self.ipaddress))
+
 class SecureRenegoOverflow(Probe):
     '''Send secure renegotiation with data length exceeding stated size'''
 


### PR DESCRIPTION
Since not all servers support all name types in the SNI extension (e.g. openssl chokes on them, IIS processes them), add tests to check which variants are unsupported and which are supported
