### PR TITLE
PFS and TLSv1.2 ciphers and probes

### DIFF
--- a/fingerprints/apache-tomcat-7054-jsse-bio-java-18040.fp
+++ b/fingerprints/apache-tomcat-7054-jsse-bio-java-18040.fp
@@ -3,7 +3,7 @@ Description: Apache Tomcat 7.0.54 (JSSE; BIO; Java 1.8.0_40)
 ZeroHelloVersion: *(303)alert:HandshakeFailure:fatal|
 BadContentType: *(303)alert:UnexpectedMesage:fatal|
 SNIEmptyName: *(303)alert:UnexpectedMesage:fatal|
-SplitHelloRecords: *(303)alert:UnexpectedMesage:fatal|
+TwoInvalidPackets: *(303)alert:UnexpectedMesage:fatal|
 EmptyRecord: *(301)handshake:ServerHello(301)|handshake:Certificate|handshake:ServerHelloDone|
 RecordLengthUnderflow: writeerror:ECONNRESET|
 Heartbleed: *(301)handshake:ServerHello(301)|handshake:Certificate|handshake:ServerHelloDone|

--- a/fingerprints/apache-tomcat-7054-jsse-nio-java-18040.fp
+++ b/fingerprints/apache-tomcat-7054-jsse-nio-java-18040.fp
@@ -3,7 +3,7 @@ Description: Apache Tomcat 7.0.54 (JSSE; NIO; Java 1.8.0_40)
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: error:Unexpected EOF receiving record header - server closed connection|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: *(301)handshake:ServerHello(301)|handshake:Certificate|handshake:ServerHelloDone|
 RecordLengthUnderflow: error:Unexpected EOF receiving record header - server closed connection|
 Heartbleed: *(301)handshake:ServerHello(301)|handshake:Certificate|handshake:ServerHelloDone|

--- a/fingerprints/apache-tomcat-7054-tomcat-native-1130-apr-148.fp
+++ b/fingerprints/apache-tomcat-7054-tomcat-native-1130-apr-148.fp
@@ -3,7 +3,7 @@ Description: Apache Tomcat 7.0.54 (Tomcat Native 1.1.30; APR 1.4.8)
 ZeroHelloVersion: *(301)alert:ProtocolVersion:fatal|
 BadContentType: error:timeout
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:ECONNRESET|
+TwoInvalidPackets: error:ECONNRESET|
 EmptyRecord: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|
 RecordLengthUnderflow: writeerror:ECONNRESET|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/axtls152.fp
+++ b/fingerprints/axtls152.fp
@@ -9,7 +9,7 @@ BadContentType: *(300)alert:HandshakeFailure:fatal|
 VeryHighTLSVersion: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|
 RecordLengthOverflow: *(300)alert:HandshakeFailure:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|*(301)alert:HandshakeFailure:fatal|
-SplitHelloRecords: writeerror:EPIPE|
+TwoInvalidPackets: writeerror:EPIPE|
 VeryHighHelloVersion: *(302)handshake:ServerHello(302)|*(302)handshake:Certificate|*(302)handshake:ServerHelloDone|
 EmptyChangeCipherSpec: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|
 ChangeCipherSpec: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|*(301)alert:HandshakeFailure:fatal|

--- a/fingerprints/f5-bigip-1141-build-6750-hotfix-hf7.fp
+++ b/fingerprints/f5-bigip-1141-build-6750-hotfix-hf7.fp
@@ -3,7 +3,7 @@ Description: F5 BIG-IP 11.4.1 Build 675.0 Hotfix HF7
 ZeroHelloVersion: *(0)alert:HandshakeFailure:fatal|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:HandshakeFailure:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|*(301)alert:HandshakeFailure:fatal|

--- a/fingerprints/f5-bigip-1151-build-60159-hotfix-hf6.fp
+++ b/fingerprints/f5-bigip-1151-build-60159-hotfix-hf6.fp
@@ -3,7 +3,7 @@ Description: F5 BIG-IP 11.5.1 Build 6.0.159 Hotfix HF6
 ZeroHelloVersion: *(0)alert:HandshakeFailure:fatal|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:HandshakeFailure:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|*(301)alert:HandshakeFailure:fatal|

--- a/fingerprints/f5-bigip-1151-build-80175-hotfix-hf8.fp
+++ b/fingerprints/f5-bigip-1151-build-80175-hotfix-hf8.fp
@@ -3,7 +3,7 @@ Description: F5 BIG-IP 11.5.1 Build 8.0.175 Hotfix HF8
 ZeroHelloVersion: *(0)alert:HandshakeFailure:fatal|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:HandshakeFailure:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|*(301)alert:HandshakeFailure:fatal|

--- a/fingerprints/f5-firepass-610-urm61020091009.fp
+++ b/fingerprints/f5-firepass-610-urm61020091009.fp
@@ -3,7 +3,7 @@ Description: F5 FirePass 6.1.0 URM-6.10-20091009
 ZeroHelloVersion: error:ECONNRESET|
 BadContentType: error:ECONNRESET|
 SNIEmptyName: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|
-SplitHelloRecords: error:ECONNRESET|
+TwoInvalidPackets: error:ECONNRESET|
 EmptyRecord: error:ECONNRESET|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/fortios-v522build642-ga.fp
+++ b/fingerprints/fortios-v522build642-ga.fp
@@ -3,7 +3,7 @@ Description: FortiOS v5.2.2,build642 (GA)
 ZeroHelloVersion: error:ECONNRESET|
 BadContentType: error:ECONNRESET|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:ECONNRESET|
+TwoInvalidPackets: error:ECONNRESET|
 EmptyRecord: error:ECONNRESET|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/gnutls-3218-disable-cert-request.fp
+++ b/fingerprints/gnutls-3218-disable-cert-request.fp
@@ -3,7 +3,7 @@ Description: GnuTLS 3.2.18 disable cert request
 ZeroHelloVersion: *(303)handshake:ServerHello(303)|*(303)handshake:Certificate|*(303)handshake:ServerHelloDone|
 BadContentType: *(303)alert:UnexpectedMesage:fatal|
 SNIEmptyName: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|
-SplitHelloRecords: *(303)alert:UnexpectedMesage:fatal|
+TwoInvalidPackets: *(303)alert:UnexpectedMesage:fatal|
 EmptyRecord: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|
 RecordLengthUnderflow: writeerror:EPIPE|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|*(301)alert:UnexpectedMesage:fatal|

--- a/fingerprints/gnutls-3218.fp
+++ b/fingerprints/gnutls-3218.fp
@@ -3,7 +3,7 @@ Description: GnuTLS 3.2.18
 ZeroHelloVersion: *(303)handshake:ServerHello(303)|*(303)handshake:Certificate|*(303)handshake:CertificateRequest|*(303)handshake:ServerHelloDone|
 BadContentType: *(303)alert:UnexpectedMesage:fatal|
 SNIEmptyName: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:CertificateRequest|*(301)handshake:ServerHelloDone|
-SplitHelloRecords: *(303)alert:UnexpectedMesage:fatal|
+TwoInvalidPackets: *(303)alert:UnexpectedMesage:fatal|
 EmptyRecord: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:CertificateRequest|*(301)handshake:ServerHelloDone|
 RecordLengthUnderflow: *(303)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:CertificateRequest|*(301)handshake:ServerHelloDone|*(301)alert:UnexpectedMesage:fatal|

--- a/fingerprints/gnutls-324-disable-cert-request.fp
+++ b/fingerprints/gnutls-324-disable-cert-request.fp
@@ -9,7 +9,7 @@ BadContentType: *(303)alert:UnexpectedMesage:fatal|
 VeryHighTLSVersion: *(303)alert:ProtocolVersion:fatal|
 RecordLengthOverflow: *(303)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|*(301)alert:UnexpectedMesage:fatal|
-SplitHelloRecords: writeerror:EPIPE|
+TwoInvalidPackets: writeerror:EPIPE|
 VeryHighHelloVersion: *(303)handshake:ServerHello(303)|*(303)handshake:Certificate|*(303)handshake:ServerHelloDone|
 EmptyChangeCipherSpec: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|
 ChangeCipherSpec: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|*(301)alert:UnexpectedMesage:fatal|

--- a/fingerprints/gnutls-324.fp
+++ b/fingerprints/gnutls-324.fp
@@ -9,7 +9,7 @@ BadContentType: *(303)alert:UnexpectedMesage:fatal|
 VeryHighTLSVersion: *(303)alert:ProtocolVersion:fatal|
 RecordLengthOverflow: *(303)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:CertificateRequest|*(301)handshake:ServerHelloDone|*(301)alert:UnexpectedMesage:fatal|
-SplitHelloRecords: writeerror:EPIPE|
+TwoInvalidPackets: writeerror:EPIPE|
 VeryHighHelloVersion: *(303)handshake:ServerHello(303)|*(303)handshake:Certificate|*(303)handshake:CertificateRequest|*(303)handshake:ServerHelloDone|
 EmptyChangeCipherSpec: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:CertificateRequest|*(301)handshake:ServerHelloDone|
 ChangeCipherSpec: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:CertificateRequest|*(301)handshake:ServerHelloDone|*(301)alert:UnexpectedMesage:fatal|

--- a/fingerprints/golang-pkgcryptotls.fp
+++ b/fingerprints/golang-pkgcryptotls.fp
@@ -3,7 +3,7 @@ Description: Golang pkg/crypto/tls
 ZeroHelloVersion: *(301)alert:ProtocolVersion:fatal|
 BadContentType: *(301)alert:UnexpectedMesage:fatal|
 SNIEmptyName: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|
-SplitHelloRecords: *(301)alert:RecordOveflow:fatal|
+TwoInvalidPackets: *(301)alert:RecordOveflow:fatal|
 EmptyRecord: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|
 RecordLengthUnderflow: writeerror:ECONNRESET|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|*(301)alert:UnexpectedMesage:fatal|

--- a/fingerprints/java17071b14burpsuite.fp
+++ b/fingerprints/java17071b14burpsuite.fp
@@ -9,7 +9,7 @@ BadContentType: error:timeout
 VeryHighTLSVersion: *(301)handshake:ServerHello(301)|handshake:Certificate|handshake:ServerHelloDone|
 RecordLengthOverflow: error:timeout
 Heartbleed: *(301)handshake:ServerHello(301)|handshake:Certificate|handshake:ServerHelloDone|
-SplitHelloRecords: error:timeout
+TwoInvalidPackets: error:timeout
 VeryHighHelloVersion: *(303)handshake:ServerHello(303)|handshake:Certificate|handshake:ServerHelloDone|
 EmptyChangeCipherSpec: *(301)handshake:ServerHello(301)|handshake:Certificate|handshake:ServerHelloDone|*(301)alert:UnexpectedMesage:fatal|
 ChangeCipherSpec: *(301)handshake:ServerHello(301)|handshake:Certificate|handshake:ServerHelloDone|*(301)alert:UnexpectedMesage:fatal|

--- a/fingerprints/matrixssl-312.fp
+++ b/fingerprints/matrixssl-312.fp
@@ -3,7 +3,7 @@ Description: MatrixSSL 3.1.2
 ZeroHelloVersion: *(0)alert:ProtocolVersion:fatal|
 BadContentType: *(0)alert:UnexpectedMesage:fatal|
 SNIEmptyName: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|
-SplitHelloRecords: *(0)alert:UnexpectedMesage:fatal|
+TwoInvalidPackets: *(0)alert:UnexpectedMesage:fatal|
 EmptyRecord: *(0)alert:IllegalParameter:fatal|
 RecordLengthUnderflow: writeerror:EPIPE|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|*(301)alert:UnexpectedMesage:fatal|

--- a/fingerprints/matrixssl-371.fp
+++ b/fingerprints/matrixssl-371.fp
@@ -3,7 +3,7 @@ Description: MatrixSSL 3.7.1
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: error:Unexpected EOF receiving record header - server closed connection|
-SplitHelloRecords: writeerror:EPIPE|
+TwoInvalidPackets: writeerror:EPIPE|
 EmptyRecord: writeerror:EPIPE|
 RecordLengthUnderflow: writeerror:EPIPE|
 Heartbleed: writeerror:EPIPE|

--- a/fingerprints/matrixssl-372b.fp
+++ b/fingerprints/matrixssl-372b.fp
@@ -3,7 +3,7 @@ Description: MatrixSSL 3.7.2b
 ZeroHelloVersion: *(0)alert:ProtocolVersion:fatal|
 BadContentType: *(0)alert:UnexpectedMesage:fatal|
 SNIEmptyName: *(301)alert:IllegalParameter:fatal|
-SplitHelloRecords: *(0)alert:UnexpectedMesage:fatal|
+TwoInvalidPackets: *(0)alert:UnexpectedMesage:fatal|
 EmptyRecord: *(0)alert:IllegalParameter:fatal|
 RecordLengthUnderflow: *(0)alert:IllegalParameter:fatal|
 Heartbleed: *(301)alert:HandshakeFailure:fatal|

--- a/fingerprints/mbedtls1310.fp
+++ b/fingerprints/mbedtls1310.fp
@@ -8,7 +8,7 @@ BadContentType: error:Unexpected EOF receiving record header - server closed con
 VeryHighTLSVersion: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|
 RecordLengthOverflow: error:Unexpected EOF receiving record header - server closed connection|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|*(301)alert:UnexpectedMesage:fatal|
-SplitHelloRecords: writeerror:EPIPE|
+TwoInvalidPackets: writeerror:EPIPE|
 VeryHighHelloVersion: *(303)handshake:ServerHello(303)|*(303)handshake:Certificate|*(303)handshake:ServerHelloDone|
 ChangeCipherSpec: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|error:Unexpected EOF receiving record header - server closed connection|
 NormalHandshake: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/mbedtls221.fp
+++ b/fingerprints/mbedtls221.fp
@@ -3,7 +3,7 @@ Description: mbedtls-2.2.1
 ZeroHelloVersion: *(0)alert:ProtocolVersion:fatal|
 BadContentType: error:ECONNRESET|
 SNIEmptyName: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|
-SplitHelloRecords: error:ECONNRESET|
+TwoInvalidPackets: error:ECONNRESET|
 EmptyRecord: error:ECONNRESET|
 RecordLengthUnderflow: error:ECONNRESET|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|*(301)alert:UnexpectedMesage:fatal|

--- a/fingerprints/microsoft-iis-60.fp
+++ b/fingerprints/microsoft-iis-60.fp
@@ -3,7 +3,7 @@ Description: Microsoft IIS 6.0
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)handshake:ServerHello(301)|handshake:Certificate|handshake:ServerHelloDone|
-SplitHelloRecords: error:timeout
+TwoInvalidPackets: error:timeout
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: error:Unexpected EOF receiving record header - server closed connection|
 Heartbleed: *(301)handshake:ServerHello(301)|handshake:Certificate|handshake:ServerHelloDone|error:Unexpected EOF receiving record header - server closed connection|

--- a/fingerprints/microsoft-iis-70.fp
+++ b/fingerprints/microsoft-iis-70.fp
@@ -3,7 +3,7 @@ Description: Microsoft IIS 7.0
 ZeroHelloVersion: error:ECONNRESET|
 BadContentType: error:timeout
 SNIEmptyName: *(301)handshake:ServerHello(301)|handshake:Certificate|handshake:ServerHelloDone|
-SplitHelloRecords: error:timeout
+TwoInvalidPackets: error:timeout
 EmptyRecord: error:ECONNRESET|
 RecordLengthUnderflow: error:timeout
 Heartbleed: *(301)handshake:ServerHello(301)|handshake:Certificate|handshake:ServerHelloDone|error:ECONNRESET|

--- a/fingerprints/microsoft-iis-75.fp
+++ b/fingerprints/microsoft-iis-75.fp
@@ -3,7 +3,7 @@ Description: Microsoft IIS 7.5
 ZeroHelloVersion: error:ECONNRESET|
 BadContentType: error:ECONNRESET|
 SNIEmptyName: *(301)handshake:ServerHello(301)|handshake:Certificate|handshake:ServerHelloDone|
-SplitHelloRecords: error:ECONNRESET|
+TwoInvalidPackets: error:ECONNRESET|
 EmptyRecord: error:ECONNRESET|
 RecordLengthUnderflow: error:ECONNRESET|
 Heartbleed: *(301)handshake:ServerHello(301)|handshake:Certificate|handshake:ServerHelloDone|error:ECONNRESET|

--- a/fingerprints/microsoft-iis-80.fp
+++ b/fingerprints/microsoft-iis-80.fp
@@ -3,7 +3,7 @@ Description: Microsoft IIS 8.0
 ZeroHelloVersion: error:ECONNRESET|
 BadContentType: error:ECONNRESET|
 SNIEmptyName: *(301)handshake:ServerHello(301)|handshake:Certificate|handshake:ServerHelloDone|
-SplitHelloRecords: error:timeout
+TwoInvalidPackets: error:timeout
 EmptyRecord: error:ECONNRESET|
 RecordLengthUnderflow: error:timeout
 Heartbleed: *(301)handshake:ServerHello(301)|handshake:Certificate|handshake:ServerHelloDone|error:ECONNRESET|

--- a/fingerprints/microsoft-iis-85.fp
+++ b/fingerprints/microsoft-iis-85.fp
@@ -3,7 +3,7 @@ Description: Microsoft IIS 8.5
 ZeroHelloVersion: error:ECONNRESET|
 BadContentType: error:ECONNRESET|
 SNIEmptyName: *(301)handshake:ServerHello(301)|handshake:Certificate|handshake:ServerHelloDone|
-SplitHelloRecords: error:timeout
+TwoInvalidPackets: error:timeout
 EmptyRecord: error:ECONNRESET|
 RecordLengthUnderflow: error:timeout
 Heartbleed: *(301)handshake:ServerHello(301)|handshake:Certificate|handshake:ServerHelloDone|error:ECONNRESET|

--- a/fingerprints/openssl-098efipsrhel5-rhel-5.fp
+++ b/fingerprints/openssl-098efipsrhel5-rhel-5.fp
@@ -3,7 +3,7 @@ Description: OpenSSL 0.9.8e-fips-rhel5 RHEL 5
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|
-SplitHelloRecords: error:ECONNRESET|
+TwoInvalidPackets: error:ECONNRESET|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl-101f-debian-7-nginx.fp
+++ b/fingerprints/openssl-101f-debian-7-nginx.fp
@@ -3,7 +3,7 @@ Description: OpenSSL 1.0.1f Debian 7 nginx
 ZeroHelloVersion: error:ECONNRESET|
 BadContentType: *(5454)record:type(48)|error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: *(5454)record:type(48)|error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: *(5454)record:type(48)|error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:ECONNRESET|
 RecordLengthUnderflow: writeerror:ECONNRESET|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl-101k-debian-8-apache.fp
+++ b/fingerprints/openssl-101k-debian-8-apache.fp
@@ -3,7 +3,7 @@ Description: OpenSSL 1.0.1k Debian 8 Apache
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:ECONNRESET|
+TwoInvalidPackets: error:ECONNRESET|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl-102-default-source-build.fp
+++ b/fingerprints/openssl-102-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl 1.0.2 default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|error:Unexpected EOF receiving record header - server closed connection|

--- a/fingerprints/openssl-102a-default-source-build.fp
+++ b/fingerprints/openssl-102a-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl 1.0.2a default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|error:Unexpected EOF receiving record header - server closed connection|

--- a/fingerprints/openssl097-default-source-build.fp
+++ b/fingerprints/openssl097-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-0.9.7 default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl097a-default-source-build.fp
+++ b/fingerprints/openssl097a-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-0.9.7a default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl097b-default-source-build.fp
+++ b/fingerprints/openssl097b-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-0.9.7b default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl097c-default-source-build.fp
+++ b/fingerprints/openssl097c-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-0.9.7c default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl097d-default-source-build.fp
+++ b/fingerprints/openssl097d-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-0.9.7d default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl097e-default-source-build.fp
+++ b/fingerprints/openssl097e-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-0.9.7e default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl097f-default-source-build.fp
+++ b/fingerprints/openssl097f-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-0.9.7f default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl097g-default-source-build.fp
+++ b/fingerprints/openssl097g-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-0.9.7g default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl097h-default-source-build.fp
+++ b/fingerprints/openssl097h-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-0.9.7h default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl097i-default-source-build.fp
+++ b/fingerprints/openssl097i-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-0.9.7i default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl097j-default-source-build.fp
+++ b/fingerprints/openssl097j-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-0.9.7j default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl097k-default-source-build.fp
+++ b/fingerprints/openssl097k-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-0.9.7k default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl097l-default-source-build.fp
+++ b/fingerprints/openssl097l-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-0.9.7l default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl097m-default-source-build.fp
+++ b/fingerprints/openssl097m-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-0.9.7m default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl098m-default-source-build.fp
+++ b/fingerprints/openssl098m-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-0.9.8m default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl098n-default-source-build.fp
+++ b/fingerprints/openssl098n-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-0.9.8n default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl098o-default-source-build.fp
+++ b/fingerprints/openssl098o-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-0.9.8o default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl098p-default-source-build.fp
+++ b/fingerprints/openssl098p-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-0.9.8p default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl098q-default-source-build.fp
+++ b/fingerprints/openssl098q-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-0.9.8q default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl098r-default-source-build.fp
+++ b/fingerprints/openssl098r-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-0.9.8r default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl098s-default-source-build.fp
+++ b/fingerprints/openssl098s-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-0.9.8s default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl098t-default-source-build.fp
+++ b/fingerprints/openssl098t-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-0.9.8t default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl098u-default-source-build.fp
+++ b/fingerprints/openssl098u-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-0.9.8u default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl098v-default-source-build.fp
+++ b/fingerprints/openssl098v-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-0.9.8v default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl098w-default-source-build.fp
+++ b/fingerprints/openssl098w-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-0.9.8w default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl098x-default-source-build.fp
+++ b/fingerprints/openssl098x-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-0.9.8x default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl098y-default-source-build.fp
+++ b/fingerprints/openssl098y-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-0.9.8y default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl098za-default-source-build.fp
+++ b/fingerprints/openssl098za-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-0.9.8za default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl100-default-source-build.fp
+++ b/fingerprints/openssl100-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-1.0.0 default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl100a-default-source-build.fp
+++ b/fingerprints/openssl100a-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-1.0.0a default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl100b-default-source-build.fp
+++ b/fingerprints/openssl100b-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-1.0.0b default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl100c-default-source-build.fp
+++ b/fingerprints/openssl100c-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-1.0.0c default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl100d-default-source-build.fp
+++ b/fingerprints/openssl100d-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-1.0.0d default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl100e-default-source-build.fp
+++ b/fingerprints/openssl100e-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-1.0.0e default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl100f-default-source-build.fp
+++ b/fingerprints/openssl100f-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-1.0.0f default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl100g-default-source-build.fp
+++ b/fingerprints/openssl100g-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-1.0.0g default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl100h-default-source-build.fp
+++ b/fingerprints/openssl100h-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-1.0.0h default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl100i-default-source-build.fp
+++ b/fingerprints/openssl100i-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-1.0.0i default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl100j-default-source-build.fp
+++ b/fingerprints/openssl100j-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-1.0.0j default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl100k-default-source-build.fp
+++ b/fingerprints/openssl100k-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-1.0.0k default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl100l-default-source-build.fp
+++ b/fingerprints/openssl100l-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-1.0.0l default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl100m-default-source-build.fp
+++ b/fingerprints/openssl100m-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-1.0.0m default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl101-default-source-build.fp
+++ b/fingerprints/openssl101-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-1.0.1 default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|*(301)record:Heartbeat|

--- a/fingerprints/openssl101a-default-source-build.fp
+++ b/fingerprints/openssl101a-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-1.0.1a default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|*(301)record:Heartbeat|

--- a/fingerprints/openssl101b-default-source-build.fp
+++ b/fingerprints/openssl101b-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-1.0.1b default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|*(301)record:Heartbeat|

--- a/fingerprints/openssl101c-default-source-build.fp
+++ b/fingerprints/openssl101c-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-1.0.1c default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|*(301)record:Heartbeat|

--- a/fingerprints/openssl101d-default-source-build.fp
+++ b/fingerprints/openssl101d-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-1.0.1d default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|*(301)record:Heartbeat|

--- a/fingerprints/openssl101e-default-source-build.fp
+++ b/fingerprints/openssl101e-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-1.0.1e default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|*(301)record:Heartbeat|

--- a/fingerprints/openssl101f-default-source-build.fp
+++ b/fingerprints/openssl101f-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-1.0.1f default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|*(301)record:Heartbeat|

--- a/fingerprints/openssl101g-default-source-build.fp
+++ b/fingerprints/openssl101g-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-1.0.1g default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/openssl101h-default-source-build.fp
+++ b/fingerprints/openssl101h-default-source-build.fp
@@ -3,7 +3,7 @@ Description: openssl-1.0.1h default source build
 ZeroHelloVersion: error:Unexpected EOF receiving record header - server closed connection|
 BadContentType: error:Unexpected EOF receiving record header - server closed connection|
 SNIEmptyName: *(301)alert:DecodeError:fatal|
-SplitHelloRecords: error:Unexpected EOF receiving record header - server closed connection|
+TwoInvalidPackets: error:Unexpected EOF receiving record header - server closed connection|
 EmptyRecord: error:Unexpected EOF receiving record header - server closed connection|
 RecordLengthUnderflow: *(301)alert:RecordOveflow:fatal|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|

--- a/fingerprints/wolfssl340.fp
+++ b/fingerprints/wolfssl340.fp
@@ -9,7 +9,7 @@ BadContentType: error:ECONNRESET|
 VeryHighTLSVersion: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|
 RecordLengthOverflow: error:Unexpected EOF receiving record header - server closed connection|
 Heartbleed: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|error:ECONNRESET|
-SplitHelloRecords: writeerror:ECONNRESET|
+TwoInvalidPackets: writeerror:ECONNRESET|
 VeryHighHelloVersion: *(303)handshake:ServerHello(303)|*(303)handshake:Certificate|*(303)handshake:ServerHelloDone|
 EmptyChangeCipherSpec: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|error:Unexpected EOF receiving record header - server closed connection|
 ChangeCipherSpec: *(301)handshake:ServerHello(301)|*(301)handshake:Certificate|*(301)handshake:ServerHelloDone|error:Unexpected EOF receiving record header - server closed connection|

--- a/prober.py
+++ b/prober.py
@@ -42,6 +42,8 @@ probes = [
     HighHelloVersionNew(),
     HighHelloVersionPFS(),
     VeryHighHelloVersion(),
+    VeryHighHelloVersionNew(),
+    VeryHighHelloVersionPFS(),
     ZeroHelloVersion(),
     BadContentType(),
     RecordLengthOverflow(),

--- a/prober.py
+++ b/prober.py
@@ -39,6 +39,8 @@ probes = [
     ZeroTLSVersion12(),
     ZeroTLSVersion12PFS(),
     HighHelloVersion(),
+    HighHelloVersionNew(),
+    HighHelloVersionPFS(),
     VeryHighHelloVersion(),
     ZeroHelloVersion(),
     BadContentType(),

--- a/prober.py
+++ b/prober.py
@@ -62,6 +62,8 @@ probes = [
     SNIOverflow(),
     SNIUnderflow(),
     SecureRenegoOverflow(),
+    SecureRenegoOverflow12(),
+    SecureRenegoOverflow12PFS(),
     SecureRenegoUnderflow(),
     SecureRenegoNonEmpty(),
     SecureRenegoNull(),

--- a/prober.py
+++ b/prober.py
@@ -40,6 +40,8 @@ probes = [
     Heartbleed(),
     BadHandshakeMessage(),
     DoubleClientHello(),
+    DoubleClientHello12(),
+    DoubleClientHello12PFS(),
     EmptyRecord(),
     TwoInvalidPackets(),
     SplitHelloRecords(),

--- a/prober.py
+++ b/prober.py
@@ -46,6 +46,8 @@ probes = [
     TwoInvalidPackets(),
     SplitHelloRecords(),
     SplitHelloPackets(),
+    SplitHelloPackets12(),
+    SplitHelloPackets12PFS(),
     NoCiphers(),
     EmptyChangeCipherSpec(),
     HelloRequest(),

--- a/prober.py
+++ b/prober.py
@@ -100,6 +100,8 @@ probes = [
     SecureRenegoNonEmpty12(),
     SecureRenegoNonEmpty12PFS(),
     SecureRenegoNull(),
+    SecureRenegoNull12(),
+    SecureRenegoNull12PFS(),
     MaxFragmentNull(),
     MaxFragmentInvalid(),
     ClientCertURLsNotNull(),

--- a/prober.py
+++ b/prober.py
@@ -45,6 +45,8 @@ probes = [
     EmptyRecord(),
     TwoInvalidPackets(),
     SplitHelloRecords(),
+    SplitHelloRecords12(),
+    SplitHelloRecords12PFS(),
     SplitHelloPackets(),
     SplitHelloPackets12(),
     SplitHelloPackets12PFS(),

--- a/prober.py
+++ b/prober.py
@@ -97,6 +97,8 @@ probes = [
     SecureRenegoUnderflow12(),
     SecureRenegoUnderflow12PFS(),
     SecureRenegoNonEmpty(),
+    SecureRenegoNonEmpty12(),
+    SecureRenegoNonEmpty12PFS(),
     SecureRenegoNull(),
     MaxFragmentNull(),
     MaxFragmentInvalid(),

--- a/prober.py
+++ b/prober.py
@@ -39,6 +39,8 @@ probes = [
     RecordLengthOverflow(),
     RecordLengthUnderflow(),
     Heartbeat(),
+    Heartbeat12(),
+    Heartbeat12PFS(),
     Heartbleed(),
     BadHandshakeMessage(),
     DoubleClientHello(),

--- a/prober.py
+++ b/prober.py
@@ -80,6 +80,8 @@ probes = [
     SNIWrongName12(),
     SNIWrongName12PFS(),
     SNILongName(),
+    SNILongName12(),
+    SNILongName12PFS(),
     SNIEmptyName(),
     SNIOneWrong(),
     SNIWithDifferentType(),

--- a/prober.py
+++ b/prober.py
@@ -36,6 +36,8 @@ probes = [
     VeryHighTLSVersion12(),
     VeryHighTLSVersion12PFS(),
     ZeroTLSVersion(),
+    ZeroTLSVersion12(),
+    ZeroTLSVersion12PFS(),
     HighHelloVersion(),
     VeryHighHelloVersion(),
     ZeroHelloVersion(),

--- a/prober.py
+++ b/prober.py
@@ -21,6 +21,7 @@ __email__ = 'rich@kde.org'
 # List all the probes we have
 probes = [
     NormalHandshake(),
+    NormalHandshakePFS(),
     ChangeCipherSpec(),
     OnlyECCipherSuites(),
     HighTLSVersion(),

--- a/prober.py
+++ b/prober.py
@@ -94,6 +94,8 @@ probes = [
     SecureRenegoOverflow12(),
     SecureRenegoOverflow12PFS(),
     SecureRenegoUnderflow(),
+    SecureRenegoUnderflow12(),
+    SecureRenegoUnderflow12PFS(),
     SecureRenegoNonEmpty(),
     SecureRenegoNull(),
     MaxFragmentNull(),

--- a/prober.py
+++ b/prober.py
@@ -23,6 +23,7 @@ probes = [
     NormalHandshake(),
     NormalHandshakePFS(),
     NormalHandshake12(),
+    NormalHandshake12PFS(),
     ChangeCipherSpec(),
     OnlyECCipherSuites(),
     HighTLSVersion(),

--- a/prober.py
+++ b/prober.py
@@ -41,6 +41,7 @@ probes = [
     BadHandshakeMessage(),
     DoubleClientHello(),
     EmptyRecord(),
+    TwoInvalidPackets(),
     SplitHelloRecords(),
     SplitHelloPackets(),
     NoCiphers(),

--- a/prober.py
+++ b/prober.py
@@ -26,6 +26,8 @@ probes = [
     NormalHandshake12PFS(),
     NormalHandshake12PFSw13(),
     ChangeCipherSpec(),
+    ChangeCipherSpec12(),
+    ChangeCipherSpec12PFS(),
     OnlyECCipherSuites(),
     HighTLSVersion(),
     VeryHighTLSVersion(),

--- a/prober.py
+++ b/prober.py
@@ -77,6 +77,8 @@ probes = [
     HelloRequest12(),
     HelloRequest12PFS(),
     SNIWrongName(),
+    SNIWrongName12(),
+    SNIWrongName12PFS(),
     SNILongName(),
     SNIEmptyName(),
     SNIOneWrong(),

--- a/prober.py
+++ b/prober.py
@@ -42,6 +42,8 @@ probes = [
     Heartbeat12(),
     Heartbeat12PFS(),
     Heartbleed(),
+    Heartbleed12(),
+    Heartbleed12PFS(),
     BadHandshakeMessage(),
     DoubleClientHello(),
     DoubleClientHello12(),

--- a/prober.py
+++ b/prober.py
@@ -55,6 +55,8 @@ probes = [
     NoCiphers(),
     EmptyChangeCipherSpec(),
     HelloRequest(),
+    HelloRequest12(),
+    HelloRequest12PFS(),
     SNIWrongName(),
     SNILongName(),
     SNIEmptyName(),

--- a/prober.py
+++ b/prober.py
@@ -83,6 +83,8 @@ probes = [
     SNILongName12(),
     SNILongName12PFS(),
     SNIEmptyName(),
+    SNIEmptyName12(),
+    SNIEmptyName12PFS(),
     SNIOneWrong(),
     SNIWithDifferentType(),
     SNIDifferentTypeRev(),

--- a/prober.py
+++ b/prober.py
@@ -69,6 +69,7 @@ probes = [
     SplitHelloPackets12(),
     SplitHelloPackets12PFS(),
     NoCiphers(),
+    NoCiphers12(),
     EmptyChangeCipherSpec(),
     EmptyChangeCipherSpec12(),
     EmptyChangeCipherSpec12PFS(),

--- a/prober.py
+++ b/prober.py
@@ -24,6 +24,7 @@ probes = [
     NormalHandshakePFS(),
     NormalHandshake12(),
     NormalHandshake12PFS(),
+    NormalHandshake12PFSw13(),
     ChangeCipherSpec(),
     OnlyECCipherSuites(),
     HighTLSVersion(),

--- a/prober.py
+++ b/prober.py
@@ -59,6 +59,8 @@ probes = [
     DoubleClientHello12(),
     DoubleClientHello12PFS(),
     EmptyRecord(),
+    EmptyRecord12(),
+    EmptyRecord12PFS(),
     TwoInvalidPackets(),
     SplitHelloRecords(),
     SplitHelloRecords12(),

--- a/prober.py
+++ b/prober.py
@@ -33,6 +33,8 @@ probes = [
     HighTLSVersion12(),
     HighTLSVersion12PFS(),
     VeryHighTLSVersion(),
+    VeryHighTLSVersion12(),
+    VeryHighTLSVersion12PFS(),
     ZeroTLSVersion(),
     HighHelloVersion(),
     VeryHighHelloVersion(),

--- a/prober.py
+++ b/prober.py
@@ -30,6 +30,8 @@ probes = [
     ChangeCipherSpec12PFS(),
     OnlyECCipherSuites(),
     HighTLSVersion(),
+    HighTLSVersion12(),
+    HighTLSVersion12PFS(),
     VeryHighTLSVersion(),
     ZeroTLSVersion(),
     HighHelloVersion(),

--- a/prober.py
+++ b/prober.py
@@ -54,6 +54,8 @@ probes = [
     SplitHelloPackets12PFS(),
     NoCiphers(),
     EmptyChangeCipherSpec(),
+    EmptyChangeCipherSpec12(),
+    EmptyChangeCipherSpec12PFS(),
     HelloRequest(),
     HelloRequest12(),
     HelloRequest12PFS(),

--- a/prober.py
+++ b/prober.py
@@ -22,6 +22,7 @@ __email__ = 'rich@kde.org'
 probes = [
     NormalHandshake(),
     NormalHandshakePFS(),
+    NormalHandshake12(),
     ChangeCipherSpec(),
     OnlyECCipherSuites(),
     HighTLSVersion(),

--- a/prober.py
+++ b/prober.py
@@ -22,6 +22,8 @@ __email__ = 'rich@kde.org'
 probes = [
     NormalHandshake(),
     NormalHandshakePFS(),
+    NormalHandshake11(),
+    NormalHandshake11PFS(),
     NormalHandshake12(),
     NormalHandshake12PFS(),
     NormalHandshake12PFSw13(),

--- a/prober_utils.py
+++ b/prober_utils.py
@@ -137,6 +137,19 @@ def make_12_hello():
     return record.bytes
 
 
+def make_12_pfs_hello():
+    hello = ClientHelloMessage.create(TLSRecord.TLS1_2,
+                                      '01234567890123456789012345678901',
+                                      DEFAULT_PFS_CIPHERS)
+
+    record = TLSRecord.create(content_type=TLSRecord.Handshake,
+                              version=TLSRecord.TLS1_0,
+                              message=hello.bytes)
+
+    #hexdump(record.bytes)
+    return record.bytes
+
+
 def make_hello_request():
     hello_req = HandshakeMessage.create(HandshakeMessage.HelloRequest,
                                         b'')

--- a/prober_utils.py
+++ b/prober_utils.py
@@ -163,11 +163,11 @@ def make_hello_request():
                               message=hello_req.bytes)
     return record.bytes
 
-def make_ccs():
+def make_ccs(version=TLSRecord.TLS1_0):
     ccs = '\1'
 
     record = TLSRecord.create(content_type=TLSRecord.ChangeCipherSpec,
-                              version=TLSRecord.TLS1_0,
+                              version=version,
                               message=ccs)
 
     return record.bytes

--- a/prober_utils.py
+++ b/prober_utils.py
@@ -155,13 +155,14 @@ def make_12_pfs_hello(extensions=tuple()):
     return record.bytes
 
 
-def make_hello_request():
+def make_hello_request(version=TLSRecord.TLS1_0):
     hello_req = HandshakeMessage.create(HandshakeMessage.HelloRequest,
                                         b'')
     record = TLSRecord.create(content_type=TLSRecord.Handshake,
-                              version=TLSRecord.TLS1_0,
+                              version=version,
                               message=hello_req.bytes)
     return record.bytes
+
 
 def make_ccs(version=TLSRecord.TLS1_0):
     ccs = '\1'

--- a/prober_utils.py
+++ b/prober_utils.py
@@ -127,6 +127,34 @@ def make_pfs_hello(extensions=tuple()):
     return record.bytes
 
 
+def make_11_hello(extensions=tuple()):
+    hello = ClientHelloMessage.create(TLSRecord.TLS1_1,
+                                      '01234567890123456789012345678901',
+                                      DEFAULT_12_CIPHERS,
+                                      extensions=extensions)
+
+    record = TLSRecord.create(content_type=TLSRecord.Handshake,
+                              version=TLSRecord.TLS1_0,
+                              message=hello.bytes)
+
+    #hexdump(record.bytes)
+    return record.bytes
+
+
+def make_11_pfs_hello(extensions=tuple()):
+    hello = ClientHelloMessage.create(TLSRecord.TLS1_1,
+                                      '01234567890123456789012345678901',
+                                      DEFAULT_PFS_CIPHERS,
+                                      extensions=extensions)
+
+    record = TLSRecord.create(content_type=TLSRecord.Handshake,
+                              version=TLSRecord.TLS1_0,
+                              message=hello.bytes)
+
+    #hexdump(record.bytes)
+    return record.bytes
+
+
 def make_12_hello(extensions=tuple()):
     hello = ClientHelloMessage.create(TLSRecord.TLS1_2,
                                       '01234567890123456789012345678901',

--- a/prober_utils.py
+++ b/prober_utils.py
@@ -21,6 +21,58 @@ DEFAULT_CIPHERS = [TLS_RSA_WITH_RC4_128_MD5,
                    # TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
                    # TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256]
 
+DEFAULT_PFS_CIPHERS = [TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+                       TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+                       TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,
+                       TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+                       TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+                       TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+                       TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+                       TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+                       TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,
+                       TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+                       TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+                       TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+                       TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,
+                       TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,
+                       TLS_DHE_RSA_WITH_AES_256_CBC_SHA256,
+                       TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,
+                       TLS_DHE_RSA_WITH_AES_256_CBC_SHA,
+                       TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
+                       # ChaCha20
+                       0xCCA9,  # ECDHE_ECDSA [ietf]
+                       0xCCA2,  # ECDHE_ECDSA [nmav]
+                       0xCC14,  # ECDHE_ECDSA [agl]
+                       0xCCA8,  # ECDHE_RSA [ietf]
+                       0xCCA1,  # ECDHE_RSA [nmav]
+                       0xCC13,  # ECDHE_RSA [agl]
+                       0xCCAA,  # DHE_RSA [ietf]
+                       0xCCA3,  # DHE_RSA [nmav]
+                       0xCC15,  # DHE_RSA [agl]
+                       # IoT stuff (maybe)
+                       TLS_ECDHE_ECDSA_WITH_AES_256_CCM,
+                       TLS_ECDHE_ECDSA_WITH_AES_128_CCM,
+                       TLS_ECDHE_ECDSA_WITH_AES_256_CCM_8,
+                       TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8,
+                       TLS_DHE_RSA_WITH_AES_256_CCM,
+                       TLS_DHE_RSA_WITH_AES_128_CCM,
+                       TLS_DHE_RSA_WITH_AES_256_CCM_8,
+                       TLS_DHE_RSA_WITH_AES_128_CCM_8,
+                       # uncommon stuff:
+                       TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,
+                       TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA,
+                       TLS_ECDHE_ECDSA_WITH_CAMELLIA_256_CBC_SHA384,
+                       TLS_ECDHE_ECDSA_WITH_ARIA_128_CBC_SHA256,
+                       TLS_ECDHE_RSA_WITH_RC4_128_SHA,
+                       TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
+                       TLS_ECDHE_RSA_WITH_CAMELLIA_256_CBC_SHA384,
+                       TLS_ECDHE_RSA_WITH_ARIA_256_CBC_SHA384,
+                       TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA,
+                       TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA,
+                       TLS_DHE_RSA_WITH_SEED_CBC_SHA,
+                       TLS_DHE_RSA_WITH_ARIA_128_CBC_SHA256
+                       ]
+
 def make_hello():
     hello = ClientHelloMessage.create(TLSRecord.TLS1_0,
                                       '01234567890123456789012345678901',
@@ -32,6 +84,20 @@ def make_hello():
 
     #hexdump(record.bytes)
     return record.bytes
+
+
+def make_pfs_hello():
+    hello = ClientHelloMessage.create(TLSRecord.TLS1_0,
+                                      '01234567890123456789012345678901',
+                                      DEFAULT_PFS_CIPHERS)
+
+    record = TLSRecord.create(content_type=TLSRecord.Handshake,
+                              version=TLSRecord.TLS1_0,
+                              message=hello.bytes)
+
+    #hexdump(record.bytes)
+    return record.bytes
+
 
 def make_hello_request():
     hello_req = HandshakeMessage.create(HandshakeMessage.HelloRequest,

--- a/prober_utils.py
+++ b/prober_utils.py
@@ -98,11 +98,13 @@ DEFAULT_PFS_CIPHERS = [TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
                        TLS_DHE_RSA_WITH_ARIA_128_CBC_SHA256
                        ]
 
-def make_hello():
+
+def make_hello(extensions=tuple()):
     hello = ClientHelloMessage.create(TLSRecord.TLS1_0,
                                       '01234567890123456789012345678901',
-                                      DEFAULT_CIPHERS)
-    
+                                      DEFAULT_CIPHERS,
+                                      extensions=extensions)
+
     record = TLSRecord.create(content_type=TLSRecord.Handshake,
                               version=TLSRecord.TLS1_0,
                               message=hello.bytes)
@@ -111,10 +113,11 @@ def make_hello():
     return record.bytes
 
 
-def make_pfs_hello():
+def make_pfs_hello(extensions=tuple()):
     hello = ClientHelloMessage.create(TLSRecord.TLS1_0,
                                       '01234567890123456789012345678901',
-                                      DEFAULT_PFS_CIPHERS)
+                                      DEFAULT_PFS_CIPHERS,
+                                      extensions=extensions)
 
     record = TLSRecord.create(content_type=TLSRecord.Handshake,
                               version=TLSRecord.TLS1_0,
@@ -124,10 +127,11 @@ def make_pfs_hello():
     return record.bytes
 
 
-def make_12_hello():
+def make_12_hello(extensions=tuple()):
     hello = ClientHelloMessage.create(TLSRecord.TLS1_2,
                                       '01234567890123456789012345678901',
-                                      DEFAULT_12_CIPHERS)
+                                      DEFAULT_12_CIPHERS,
+                                      extensions=extensions)
 
     record = TLSRecord.create(content_type=TLSRecord.Handshake,
                               version=TLSRecord.TLS1_0,
@@ -137,10 +141,11 @@ def make_12_hello():
     return record.bytes
 
 
-def make_12_pfs_hello():
+def make_12_pfs_hello(extensions=tuple()):
     hello = ClientHelloMessage.create(TLSRecord.TLS1_2,
                                       '01234567890123456789012345678901',
-                                      DEFAULT_PFS_CIPHERS)
+                                      DEFAULT_PFS_CIPHERS,
+                                      extensions=extensions)
 
     record = TLSRecord.create(content_type=TLSRecord.Handshake,
                               version=TLSRecord.TLS1_0,

--- a/prober_utils.py
+++ b/prober_utils.py
@@ -21,6 +21,31 @@ DEFAULT_CIPHERS = [TLS_RSA_WITH_RC4_128_MD5,
                    # TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
                    # TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256]
 
+# DEFAULT_CIPHERS extended for non-PFS TLSv1.2-only connections
+DEFAULT_12_CIPHERS = [TLS_RSA_WITH_RC4_128_MD5,
+                      TLS_RSA_WITH_RC4_128_SHA,
+                      TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+                      TLS_RSA_WITH_AES_128_CBC_SHA,
+                      TLS_RSA_WITH_AES_256_CBC_SHA,
+                      TLS_RSA_WITH_AES_128_CBC_SHA256,
+                      TLS_RSA_WITH_AES_256_CBC_SHA256,
+                      TLS_RSA_WITH_AES_128_GCM_SHA256,
+                      TLS_RSA_WITH_AES_256_GCM_SHA384,
+                      # ChaCha20
+                      0xCCA0,  # RSA [nmav]
+                      # IoT
+                      TLS_RSA_WITH_AES_128_CCM,
+                      TLS_RSA_WITH_AES_256_CCM,
+                      TLS_RSA_WITH_AES_128_CCM_8,
+                      TLS_RSA_WITH_AES_256_CCM_8,
+                      # uncommon stuff:
+                      TLS_RSA_WITH_CAMELLIA_128_CBC_SHA,
+                      TLS_RSA_WITH_CAMELLIA_256_CBC_SHA,
+                      TLS_RSA_WITH_CAMELLIA_128_CBC_SHA256,
+                      TLS_RSA_WITH_ARIA_128_CBC_SHA256,
+                      TLS_RSA_WITH_SEED_CBC_SHA
+                     ]
+
 DEFAULT_PFS_CIPHERS = [TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
                        TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
                        TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,
@@ -90,6 +115,19 @@ def make_pfs_hello():
     hello = ClientHelloMessage.create(TLSRecord.TLS1_0,
                                       '01234567890123456789012345678901',
                                       DEFAULT_PFS_CIPHERS)
+
+    record = TLSRecord.create(content_type=TLSRecord.Handshake,
+                              version=TLSRecord.TLS1_0,
+                              message=hello.bytes)
+
+    #hexdump(record.bytes)
+    return record.bytes
+
+
+def make_12_hello():
+    hello = ClientHelloMessage.create(TLSRecord.TLS1_2,
+                                      '01234567890123456789012345678901',
+                                      DEFAULT_12_CIPHERS)
 
     record = TLSRecord.create(content_type=TLSRecord.Handshake,
                               version=TLSRecord.TLS1_0,

--- a/probes.py
+++ b/probes.py
@@ -156,6 +156,22 @@ class NormalHandshakePFS(NormalHandshake):
         self.make_hello = make_pfs_hello
 
 
+class NormalHandshake11(NormalHandshake):
+    '''Normal TLSv1.1 handshake'''
+
+    def __init__(self):
+        super(NormalHandshake11, self).__init__()
+        self.make_hello = make_11_hello
+
+
+class NormalHandshake11PFS(NormalHandshake):
+    '''Normal TLSv1.1 handshake'''
+
+    def __init__(self):
+        super(NormalHandshake11PFS, self).__init__()
+        self.make_hello = make_11_pfs_hello
+
+
 class NormalHandshake12(NormalHandshake):
     '''Normal TLSv1.2 handshake'''
 

--- a/probes.py
+++ b/probes.py
@@ -168,6 +168,26 @@ class NormalHandshake12PFS(Probe):
         sock.write(make_12_pfs_hello())
 
 
+class NormalHandshake12PFSw13(Probe):
+    '''TLSv1.2 with PFS ciphers with a TLSv1.3 version (invalid TLSv1.3)'''
+
+    def make_hello(self):
+        hello = ClientHelloMessage.create(TLSRecord.TLS1_3,
+                                          '01234567890123456789012345678901',
+                                          DEFAULT_PFS_CIPHERS)
+
+        record = TLSRecord.create(content_type=TLSRecord.Handshake,
+                                  version=TLSRecord.TLS1_0,
+                                  message=hello.bytes)
+
+        #hexdump(record.bytes)
+        return record.bytes
+
+    def test(self, sock):
+        logging.debug('Sending Client Hello...')
+        sock.write(self.make_hello())
+
+
 class DoubleClientHello(Probe):
     '''Two client hellos'''
     

--- a/probes.py
+++ b/probes.py
@@ -255,6 +255,19 @@ class HelloRequest(NormalHandshake):
         sock.write(self.make_hello_request(self.record_version))
 
 
+class HelloRequest12(HelloRequest, NormalHandshake12):
+    '''Send a TLSv1.2 hello then hello request'''
+
+    def __init__(self):
+        super(HelloRequest12, self).__init__()
+        self.record_version = TLSRecord.TLS1_2
+
+
+class HelloRequest12PFS(NormalHandshake12PFS, HelloRequest12):
+    '''Send a PFS TLSv1.2 hello then hello request'''
+    pass
+
+
 class EmptyChangeCipherSpec(Probe):
     '''Send a hello then an empty change cipher spec'''
     

--- a/probes.py
+++ b/probes.py
@@ -507,12 +507,17 @@ class ZeroTLSVersion12PFS(HighTLSVersion12PFS, ZeroTLSVersion):
 
 class HighHelloVersion(Probe):
     '''Set a high version in the hello'''
-    
+
+    def __init__(self):
+        super(HighHelloVersion, self).__init__()
+        self.hello_version = 0x400
+        self.hello_ciphers = DEFAULT_CIPHERS
+
     def make_high_tls_hello(self):
-        hello = ClientHelloMessage.create(0x400,
+        hello = ClientHelloMessage.create(self.hello_version,
                                           '01234567890123456789012345678901',
-                                          DEFAULT_CIPHERS)
-    
+                                          self.hello_ciphers)
+
         record = TLSRecord.create(content_type=TLSRecord.Handshake,
                                   version=settings['default_record_version'],
                                   message=hello.bytes)

--- a/probes.py
+++ b/probes.py
@@ -144,6 +144,14 @@ class NormalHandshake(Probe):
         sock.write(make_hello())
 
 
+class NormalHandshakePFS(Probe):
+    '''Normal handshake with PFS ciphersuites'''
+
+    def test(self, sock):
+        logging.debug('Sending Client Hello...')
+        sock.write(make_pfs_hello())
+
+
 class DoubleClientHello(Probe):
     '''Two client hellos'''
     

--- a/probes.py
+++ b/probes.py
@@ -844,6 +844,16 @@ class SNIWrongName(NormalHandshake):
         sock.write(self.make_sni_hello('thisisnotyourname'))
 
 
+class SNIWrongName12(NormalHandshake12, SNIWrongName):
+    '''Send a server name indication for non-matching name in TLSv1.2 hello'''
+    pass
+
+
+class SNIWrongName12PFS(NormalHandshake12PFS, SNIWrongName):
+    '''Send a SNI extension for non-matching name in PFS TLSv1.2 hello'''
+    pass
+
+
 class SNILongName(SNIWrongName):
     '''Send a server name indication with a long name'''
     

--- a/probes.py
+++ b/probes.py
@@ -802,12 +802,16 @@ class SplitHelloPackets12PFS(SplitHelloPackets, NormalHandshake12PFS):
 
 class NoCiphers(Probe):
     '''Send an empty cipher list'''
-    
+
+    def __init__(self):
+        super(NoCiphers, self).__init__()
+        self.hello_version = settings['default_hello_version']
+
     def make_no_ciphers_hello(self):
-        hello = ClientHelloMessage.create(settings['default_hello_version'],
+        hello = ClientHelloMessage.create(self.hello_version,
                                           '01234567890123456789012345678901',
                                           [])
-    
+
         record = TLSRecord.create(content_type=TLSRecord.Handshake,
                                   version=settings['default_record_version'],
                                   message=hello.bytes)

--- a/probes.py
+++ b/probes.py
@@ -391,22 +391,16 @@ class Heartbeat12PFS(NormalHandshake12PFS, Heartbeat12):
 class Heartbleed(Heartbeat):
     '''Try to send a heartbleed attack'''
 
-    def make_heartbleed(self):
+    def make_heartbeat(self):
         heartbeat = HeartbeatMessage.create(HeartbeatMessage.HeartbeatRequest,
                                             'XXXX', 0x4000)
 
         record = TLSRecord.create(content_type=TLSRecord.Heartbeat,
-                                  version=TLSRecord.TLS1_0,
+                                  version=self.record_version,
                                   message=heartbeat.bytes)
-        
+
         #hexdump(record.bytes)
         return record.bytes
-
-    def test(self, sock):
-        logging.debug('Sending Client Hello...')
-        sock.write(self.make_hb_hello())
-        logging.debug('Sending Heartbleed...')
-        sock.write(self.make_heartbleed())
 
 
 class HighTLSVersion(Probe):

--- a/probes.py
+++ b/probes.py
@@ -546,24 +546,12 @@ class HighHelloVersionPFS(HighHelloVersion):
         self.hello_ciphers = DEFAULT_PFS_CIPHERS
 
 
-class VeryHighHelloVersion(Probe):
+class VeryHighHelloVersion(HighHelloVersion):
     '''Set a very high version in the hello'''
-    
-    def make_high_tls_hello(self):
-        hello = ClientHelloMessage.create(0xffff,
-                                          '01234567890123456789012345678901',
-                                          DEFAULT_CIPHERS)
-    
-        record = TLSRecord.create(content_type=TLSRecord.Handshake,
-                                  version=settings['default_record_version'],
-                                  message=hello.bytes)
 
-        #hexdump(record.bytes)
-        return record.bytes
-
-    def test(self, sock):
-        logging.debug('Sending Client Hello...')
-        sock.write(self.make_high_tls_hello())
+    def __init__(self):
+        super(VeryHighHelloVersion, self).__init__()
+        self.hello_version = 0xffff
 
 
 class ZeroHelloVersion(Probe):

--- a/probes.py
+++ b/probes.py
@@ -471,6 +471,16 @@ class VeryHighTLSVersion(HighTLSVersion):
         return record.bytes
 
 
+class VeryHighTLSVersion12(HighTLSVersion12, VeryHighTLSVersion):
+    '''Set a very high TLS version in the record of TLSv1.2 hello'''
+    pass
+
+
+class VeryHighTLSVersion12PFS(HighTLSVersion12PFS, VeryHighTLSVersion):
+    '''Set a very high TLS version in the record of PFS TLSv1.2 hello'''
+    pass
+
+
 class ZeroTLSVersion(Probe):
     '''Set a zero version in the record'''
     

--- a/probes.py
+++ b/probes.py
@@ -1086,6 +1086,16 @@ class SecureRenegoNull(SecureRenegoOverflow):
         sock.write(self.make_secure_renego_ext(''))
 
 
+class SecureRenegoNull12(SecureRenegoNull, NormalHandshake12):
+    '''As with SecureRenegoNull, but in TLSv1.2 hello'''
+    pass
+
+
+class SecureRenegoNull12PFS(SecureRenegoNull, NormalHandshake12PFS):
+    '''As with SecureRenegoNull, but in PFS TLSv1.2 hello'''
+    pass
+
+
 class MaxFragmentNull(Probe):
     '''Send maximum fragment length extension that is completely empty'''
 

--- a/probes.py
+++ b/probes.py
@@ -556,6 +556,24 @@ class EmptyRecord(Probe):
         sock.write(make_hello())
 
 
+class TwoInvalidPackets(Probe):
+    '''Send two invalid messages'''
+
+    def test(self, sock):
+        logging.debug('Sending split hello...')
+        part_one = '<tls.record.TLSRecord object at 0x7fd2dc0906d0>'
+        part_two = '<tls.record.TLSRecord object at 0x7fd2dc090690>'
+        sock.write(part_one)
+        try:
+            sock.write(part_two)
+        except socket.timeout, e:
+            result = 'writeerror:timeout'
+            return result
+        except socket.error, e:
+            result = 'writeerror:%s|' % errno.errorcode[e.errno]
+            return result
+
+
 class SplitHelloRecords(Probe):
     '''Split the hello over two records'''
 
@@ -575,7 +593,7 @@ class SplitHelloRecords(Probe):
                                       message=second)
 
         #hexdump(record.bytes)
-        return record_one, record_two
+        return record_one.bytes, record_two.bytes
 
     def test(self, sock):
         logging.debug('Sending split hello...')
@@ -589,7 +607,6 @@ class SplitHelloRecords(Probe):
         except socket.error, e:
             result = 'writeerror:%s|' % errno.errorcode[e.errno]
             return result
-
 
 class SplitHelloPackets(Probe):
     '''Split the hello over two packets'''

--- a/probes.py
+++ b/probes.py
@@ -346,21 +346,25 @@ class OnlyECCipherSuites(Probe):
         sock.write(self.make_ec_hello())
 
 
-class Heartbeat(Probe):
+class Heartbeat(NormalHandshake):
     '''Try to send a heartbeat message'''
-    
+
+    def __init__(self):
+        super(Heartbeat, self).__init__()
+        self.record_version = TLSRecord.TLS1_0
+
     def make_hb_hello(self):
         hb_extension = HeartbeatExtension.create()
-        return make_hello([hb_extension])
+        return self.make_hello([hb_extension])
 
     def make_heartbeat(self):
         heartbeat = HeartbeatMessage.create(HeartbeatMessage.HeartbeatRequest,
                                             'XXXX')
 
         record = TLSRecord.create(content_type=TLSRecord.Heartbeat,
-                                  version=TLSRecord.TLS1_0,
+                                  version=self.record_version,
                                   message=heartbeat.bytes)
-        
+
         #hexdump(record.bytes)
         return record.bytes
 

--- a/probes.py
+++ b/probes.py
@@ -832,12 +832,12 @@ class NoCiphers12(NoCiphers):
         self.hello_version = TLSRecord.TLS1_2
 
 
-class SNIWrongName(Probe):
+class SNIWrongName(NormalHandshake):
     '''Send a server name indication for a non-matching name'''
 
     def make_sni_hello(self, name):
         sni_extension = ServerNameExtension.create(name)
-        return make_hello([sni_extension])
+        return self.make_hello([sni_extension])
 
     def test(self, sock):
         logging.debug('Sending Client Hello...')

--- a/probes.py
+++ b/probes.py
@@ -415,12 +415,16 @@ class Heartbleed12PFS(Heartbeat12PFS, Heartbleed):
 
 class HighTLSVersion(Probe):
     '''Set a high TLS version in the record'''
-    
-    def make_high_tls_hello(self):
+
+    def make_hello(self):
         hello = ClientHelloMessage.create(settings['default_hello_version'],
                                           '01234567890123456789012345678901',
                                           DEFAULT_CIPHERS)
-    
+        return hello
+
+    def make_high_tls_hello(self):
+        hello = self.make_hello()
+
         record = TLSRecord.create(content_type=TLSRecord.Handshake,
                                   version=0x400,
                                   message=hello.bytes)

--- a/probes.py
+++ b/probes.py
@@ -403,6 +403,16 @@ class Heartbleed(Heartbeat):
         return record.bytes
 
 
+class Heartbleed12(Heartbeat12, Heartbleed):
+    '''Try to send a heartbleed attack in TLSv1.2'''
+    pass
+
+
+class Heartbleed12PFS(Heartbeat12PFS, Heartbleed):
+    '''Try to send a heartbleed attack in TLSv1.2'''
+    pass
+
+
 class HighTLSVersion(Probe):
     '''Set a high TLS version in the record'''
     

--- a/probes.py
+++ b/probes.py
@@ -879,6 +879,17 @@ class SNIEmptyName(SNIWrongName):
         logging.debug('Sending Client Hello...')
         sock.write(self.make_sni_hello(''))
 
+
+class SNIEmptyName12(NormalHandshake12, SNIEmptyName):
+    '''Send a server name indication with an empty name in TLSv1.2 hello'''
+    pass
+
+
+class SNIEmptyName12PFS(NormalHandshake12PFS, SNIEmptyName):
+    '''Send a server name indication with an empty name in PFS TLSv1.2 hello'''
+    pass
+
+
 class SNIOneWrong(Probe):
     '''Send server name indication with two names, one wrong'''
 

--- a/probes.py
+++ b/probes.py
@@ -824,6 +824,14 @@ class NoCiphers(Probe):
         sock.write(self.make_no_ciphers_hello())
 
 
+class NoCiphers12(NoCiphers):
+    '''Send and empty cipher list in TLSv1.2 hello'''
+
+    def __init__(self):
+        super(NoCiphers12, self).__init__()
+        self.hello_version = TLSRecord.TLS1_2
+
+
 class SNIWrongName(Probe):
     '''Send a server name indication for a non-matching name'''
 

--- a/probes.py
+++ b/probes.py
@@ -1045,6 +1045,17 @@ class SecureRenegoUnderflow(SecureRenegoOverflow):
         # are just padding to make the extension large
         sock.write(self.make_secure_renego_ext('\x00\x00\x00\x00\x00'))
 
+
+class SecureRenegoUnderflow12(SecureRenegoUnderflow, NormalHandshake12):
+    '''As with SecureRenegoUnderflow, inside TLSv1.2 hello'''
+    pass
+
+
+class SecureRenegoUnderflow12PFS(SecureRenegoUnderflow, NormalHandshake12PFS):
+    '''As with SecureRenegoUnderflow, inside PFS TLSv1.2 hello'''
+    pass
+
+
 class SecureRenegoNonEmpty(SecureRenegoOverflow):
     '''Send secure renegotiation with renegotiation payload'''
 

--- a/probes.py
+++ b/probes.py
@@ -554,6 +554,16 @@ class VeryHighHelloVersion(HighHelloVersion):
         self.hello_version = 0xffff
 
 
+class VeryHighHelloVersionNew(HighHelloVersionNew, VeryHighHelloVersion):
+    '''Set a very high version in the hello with more ciphers'''
+    pass
+
+
+class VeryHighHelloVersionPFS(HighHelloVersionPFS, VeryHighHelloVersion):
+    '''Set a very high version in the hello with PFS ciphers'''
+    pass
+
+
 class ZeroHelloVersion(Probe):
     '''Set a zero version in the hello'''
     

--- a/probes.py
+++ b/probes.py
@@ -495,6 +495,16 @@ class ZeroTLSVersion(HighTLSVersion):
         return record.bytes
 
 
+class ZeroTLSVersion12(HighTLSVersion12, ZeroTLSVersion):
+    '''Set a zero version in the record of TLSv1.2 hello'''
+    pass
+
+
+class ZeroTLSVersion12PFS(HighTLSVersion12PFS, ZeroTLSVersion):
+    '''Set a zero version in the record of PFS TLSv1.2 hello'''
+    pass
+
+
 class HighHelloVersion(Probe):
     '''Set a high version in the hello'''
     

--- a/probes.py
+++ b/probes.py
@@ -653,7 +653,7 @@ class RecordLengthUnderflow(Probe):
             return result
 
 
-class EmptyRecord(Probe):
+class EmptyRecord(NormalHandshake):
     '''Send an empty record then the hello'''
 
     def make_empty_record(self):
@@ -667,7 +667,8 @@ class EmptyRecord(Probe):
     def test(self, sock):
         logging.debug('Sending empty record...')
         sock.write(self.make_empty_record())
-        sock.write(make_hello())
+        logging.debug('Sending Client Hello...')
+        sock.write(self.make_hello())
 
 
 class TwoInvalidPackets(Probe):

--- a/probes.py
+++ b/probes.py
@@ -1065,6 +1065,17 @@ class SecureRenegoNonEmpty(SecureRenegoOverflow):
         # payload (indicating renegotiated connection)
         sock.write(self.make_secure_renego_ext('\x0c012345678901'))
 
+
+class SecureRenegoNonEmpty12(SecureRenegoNonEmpty, NormalHandshake12):
+    '''Send secure renegotiation with renegotiation payload in TLSv1.2 hello'''
+    pass
+
+
+class SecureRenegoNonEmpty12PFS(SecureRenegoNonEmpty, NormalHandshake12PFS):
+    '''As with SecureRenegoNonEmpty12, but with PFS ciphers'''
+    pass
+
+
 class SecureRenegoNull(SecureRenegoOverflow):
     '''Send secure renegotiation extension that is completely empty'''
 

--- a/probes.py
+++ b/probes.py
@@ -481,24 +481,18 @@ class VeryHighTLSVersion12PFS(HighTLSVersion12PFS, VeryHighTLSVersion):
     pass
 
 
-class ZeroTLSVersion(Probe):
+class ZeroTLSVersion(HighTLSVersion):
     '''Set a zero version in the record'''
-    
-    def make_zero_tls_hello(self):
-        hello = ClientHelloMessage.create(settings['default_hello_version'],
-                                          '01234567890123456789012345678901',
-                                          DEFAULT_CIPHERS)
-    
+
+    def make_high_tls_hello(self):
+        hello = self.make_hello()
+
         record = TLSRecord.create(content_type=TLSRecord.Handshake,
                                   version=0x000,
                                   message=hello.bytes)
 
         #hexdump(record.bytes)
         return record.bytes
-
-    def test(self, sock):
-        logging.debug('Sending Client Hello...')
-        sock.write(self.make_zero_tls_hello())
 
 
 class HighHelloVersion(Probe):

--- a/probes.py
+++ b/probes.py
@@ -152,6 +152,14 @@ class NormalHandshakePFS(Probe):
         sock.write(make_pfs_hello())
 
 
+class NormalHandshake12(Probe):
+    '''Normal TLSv1.2 handshake'''
+
+    def test(self, sock):
+        logging.debug('Sending Client Hello...')
+        sock.write(make_12_hello())
+
+
 class DoubleClientHello(Probe):
     '''Two client hellos'''
     

--- a/probes.py
+++ b/probes.py
@@ -240,14 +240,19 @@ class ChangeCipherSpec12PFS(NormalHandshake12PFS, ChangeCipherSpec12):
     pass
 
 
-class HelloRequest(Probe):
+class HelloRequest(NormalHandshake):
     '''Send a hello then hello request'''
+
+    def __init__(self):
+        super(HelloRequest, self).__init__()
+        self.make_hello_request = make_hello_request
+        self.record_version = TLSRecord.TLS1_0
 
     def test(self, sock):
         logging.debug('Sending Client Hello...')
-        sock.write(make_hello())
+        sock.write(self.make_hello())
         logging.debug('Sending Hello Request...')
-        sock.write(make_hello_request())
+        sock.write(self.make_hello_request(self.record_version))
 
 
 class EmptyChangeCipherSpec(Probe):

--- a/probes.py
+++ b/probes.py
@@ -437,6 +437,26 @@ class HighTLSVersion(Probe):
         sock.write(self.make_high_tls_hello())
 
 
+class HighTLSVersion12(HighTLSVersion):
+    '''Set a high TLS version in the record of TLSv1.2 hello'''
+
+    def make_hello(self):
+        hello = ClientHelloMessage.create(TLSRecord.TLS1_2,
+                                          '01234567890123456789012345678901',
+                                          DEFAULT_12_CIPHERS)
+        return hello
+
+
+class HighTLSVersion12PFS(HighTLSVersion):
+    '''Set a high TLS version in the record of PFS TLSv1.2 hello'''
+
+    def make_hello(self):
+        hello = ClientHelloMessage.create(TLSRecord.TLS1_2,
+                                          '01234567890123456789012345678901',
+                                          DEFAULT_PFS_CIPHERS)
+        return hello
+
+
 class VeryHighTLSVersion(Probe):
     '''Set a very high TLS version in the record'''
     

--- a/probes.py
+++ b/probes.py
@@ -671,6 +671,16 @@ class EmptyRecord(NormalHandshake):
         sock.write(self.make_hello())
 
 
+class EmptyRecord12(NormalHandshake12, EmptyRecord):
+    '''Send an empty record then TLSv1.2 hello'''
+    pass
+
+
+class EmptyRecord12PFS(NormalHandshake12PFS, EmptyRecord):
+    '''Send and empty record then PFS TLSv1.2 hello'''
+    pass
+
+
 class TwoInvalidPackets(Probe):
     '''Send two invalid messages'''
 

--- a/probes.py
+++ b/probes.py
@@ -283,18 +283,7 @@ class Heartbeat(Probe):
     
     def make_hb_hello(self):
         hb_extension = HeartbeatExtension.create()
-        hello = ClientHelloMessage.create(TLSRecord.TLS1_0,
-                                          '01234567890123456789012345678901',
-                                          DEFAULT_CIPHERS,
-                                          extensions = [ hb_extension ])
-
-    
-        record = TLSRecord.create(content_type=TLSRecord.Handshake,
-                                  version=TLSRecord.TLS1_0,
-                                  message=hello.bytes)
-
-        #hexdump(record.bytes)
-        return record.bytes
+        return make_hello([hb_extension])
 
     def make_heartbeat(self):
         heartbeat = HeartbeatMessage.create(HeartbeatMessage.HeartbeatRequest,
@@ -314,23 +303,8 @@ class Heartbeat(Probe):
         sock.write(self.make_heartbeat())
 
 
-class Heartbleed(Probe):
+class Heartbleed(Heartbeat):
     '''Try to send a heartbleed attack'''
-    
-    def make_hb_hello(self):
-        hb_extension = HeartbeatExtension.create()
-        hello = ClientHelloMessage.create(TLSRecord.TLS1_0,
-                                          '01234567890123456789012345678901',
-                                          DEFAULT_CIPHERS,
-                                          extensions = [ hb_extension ])
-
-    
-        record = TLSRecord.create(content_type=TLSRecord.Handshake,
-                                  version=TLSRecord.TLS1_0,
-                                  message=hello.bytes)
-
-        #hexdump(record.bytes)
-        return record.bytes
 
     def make_heartbleed(self):
         heartbeat = HeartbeatMessage.create(HeartbeatMessage.HeartbeatRequest,
@@ -642,20 +616,10 @@ class NoCiphers(Probe):
 
 class SNIWrongName(Probe):
     '''Send a server name indication for a non-matching name'''
-    
+
     def make_sni_hello(self, name):
         sni_extension = ServerNameExtension.create(name)
-        hello = ClientHelloMessage.create(TLSRecord.TLS1_0,
-                                          '01234567890123456789012345678901',
-                                          DEFAULT_CIPHERS,
-                                          extensions = [ sni_extension ])
-    
-        record = TLSRecord.create(content_type=TLSRecord.Handshake,
-                                  version=TLSRecord.TLS1_0,
-                                  message=hello.bytes)
-
-        #hexdump(record.bytes)
-        return record.bytes
+        return make_hello([sni_extension])
 
     def test(self, sock):
         logging.debug('Sending Client Hello...')
@@ -802,16 +766,7 @@ class SecureRenegoOverflow(Probe):
         secure_renego = Extension.create(
             extension_type=Extension.RenegotiationInfo,
             data=payload)
-        hello = ClientHelloMessage.create(settings['default_hello_version'],
-                                          '01234567890123456789012345678901',
-                                          DEFAULT_CIPHERS,
-                                          extensions=[secure_renego])
-
-        record = TLSRecord.create(content_type=TLSRecord.Handshake,
-                                  version=settings['default_record_version'],
-                                  message=hello.bytes)
-
-        return record.bytes
+        return make_hello([secure_renego])
 
     def test(self, sock):
         logging.debug('Sending Client Hello...')

--- a/probes.py
+++ b/probes.py
@@ -286,6 +286,20 @@ class EmptyChangeCipherSpec(NormalHandshake):
         sock.write(record.bytes)
 
 
+class EmptyChangeCipherSpec12(EmptyChangeCipherSpec, NormalHandshake12):
+    '''Send TLSv1.2 hello then an empty change cipher spec'''
+
+    def __init__(self):
+        super(EmptyChangeCipherSpec12, self).__init__()
+        self.record_version = TLSRecord.TLS1_2
+
+
+class EmptyChangeCipherSpec12PFS(NormalHandshake12PFS,
+                                 EmptyChangeCipherSpec12):
+    '''Send PFS TLSv1.2 hello then an empty change cipher spec'''
+    pass
+
+
 class BadHandshakeMessage(Probe):
     '''An invalid handshake message'''
     

--- a/probes.py
+++ b/probes.py
@@ -202,6 +202,16 @@ class DoubleClientHello(NormalHandshake):
         sock.write(self.make_hello())
 
 
+class DoubleClientHello12(DoubleClientHello, NormalHandshake12):
+    '''Two client hellos, TLSv1.2'''
+    pass
+
+
+class DoubleClientHello12PFS(DoubleClientHello, NormalHandshake12PFS):
+    '''Two client hellos, TLSv1.2 w/PFS ciphers'''
+    pass
+
+
 class ChangeCipherSpec(Probe):
     '''Send a hello then change cipher spec'''
     

--- a/probes.py
+++ b/probes.py
@@ -160,6 +160,14 @@ class NormalHandshake12(Probe):
         sock.write(make_12_hello())
 
 
+class NormalHandshake12PFS(Probe):
+    '''Normal TLSv1.2 handshake with PFS ciphersuites'''
+
+    def test(self, sock):
+        logging.debug('Sending Client Hello...')
+        sock.write(make_12_pfs_hello())
+
+
 class DoubleClientHello(Probe):
     '''Two client hellos'''
     

--- a/probes.py
+++ b/probes.py
@@ -861,6 +861,17 @@ class SNILongName(SNIWrongName):
         logging.debug('Sending Client Hello...')
         sock.write(self.make_sni_hello('x'*500))
 
+
+class SNILongName12(NormalHandshake12, SNILongName):
+    '''Send a server name indication with a long name in TLSv1.2 hello'''
+    pass
+
+
+class SNILongName12PFS(NormalHandshake12PFS, SNILongName):
+    '''Send a server name indication with a long name in PFS TLSv1.2 hello'''
+    pass
+
+
 class SNIEmptyName(SNIWrongName):
     '''Send a server name indication with an empty name'''
     

--- a/probes.py
+++ b/probes.py
@@ -212,14 +212,19 @@ class DoubleClientHello12PFS(DoubleClientHello, NormalHandshake12PFS):
     pass
 
 
-class ChangeCipherSpec(Probe):
+class ChangeCipherSpec(NormalHandshake):
     '''Send a hello then change cipher spec'''
-    
+
+    def __init__(self):
+        super(ChangeCipherSpec, self).__init__()
+        self.make_ccs = make_ccs
+        self.record_version = TLSRecord.TLS1_0
+
     def test(self, sock):
         logging.debug('Sending Client Hello...')
-        sock.write(make_hello())
+        sock.write(self.make_hello())
         logging.debug('Sending ChangeCipherSpec...')
-        sock.write(make_ccs())
+        sock.write(self.make_ccs(self.record_version))
 
 
 class HelloRequest(Probe):

--- a/probes.py
+++ b/probes.py
@@ -530,6 +530,22 @@ class HighHelloVersion(Probe):
         sock.write(self.make_high_tls_hello())
 
 
+class HighHelloVersionNew(HighHelloVersion):
+    '''Set a high version in a hello with more ciphers'''
+
+    def __init__(self):
+        super(HighHelloVersionNew, self).__init__()
+        self.hello_ciphers = DEFAULT_12_CIPHERS
+
+
+class HighHelloVersionPFS(HighHelloVersion):
+    '''Set a high version in a hello with PFS ciphers'''
+
+    def __init__(self):
+        super(HighHelloVersionPFS, self).__init__()
+        self.hello_ciphers = DEFAULT_PFS_CIPHERS
+
+
 class VeryHighHelloVersion(Probe):
     '''Set a very high version in the hello'''
     

--- a/probes.py
+++ b/probes.py
@@ -457,24 +457,18 @@ class HighTLSVersion12PFS(HighTLSVersion):
         return hello
 
 
-class VeryHighTLSVersion(Probe):
+class VeryHighTLSVersion(HighTLSVersion):
     '''Set a very high TLS version in the record'''
-    
-    def make_very_high_tls_hello(self):
-        hello = ClientHelloMessage.create(settings['default_hello_version'],
-                                          '01234567890123456789012345678901',
-                                          DEFAULT_CIPHERS)
-    
+
+    def make_high_tls_hello(self):
+        hello = self.make_hello()
+
         record = TLSRecord.create(content_type=TLSRecord.Handshake,
                                   version=0xffff,
                                   message=hello.bytes)
 
         #hexdump(record.bytes)
         return record.bytes
-
-    def test(self, sock):
-        logging.debug('Sending Client Hello...')
-        sock.write(self.make_very_high_tls_hello())
 
 
 class ZeroTLSVersion(Probe):

--- a/probes.py
+++ b/probes.py
@@ -828,14 +828,14 @@ class SNIUnderflow(Probe):
         logging.debug('Sending Client Hello...')
         sock.write(self.make_sni_hello(self.ipaddress))
 
-class SecureRenegoOverflow(Probe):
+class SecureRenegoOverflow(NormalHandshake):
     '''Send secure renegotiation with data length exceeding stated size'''
 
     def make_secure_renego_ext(self, payload):
         secure_renego = Extension.create(
             extension_type=Extension.RenegotiationInfo,
             data=payload)
-        return make_hello([secure_renego])
+        return self.make_hello([secure_renego])
 
     def test(self, sock):
         logging.debug('Sending Client Hello...')
@@ -843,6 +843,17 @@ class SecureRenegoOverflow(Probe):
         # length of the array of bytes in it, but don't provide the
         # required amount
         sock.write(self.make_secure_renego_ext('\x0c0123456789'))
+
+
+class SecureRenegoOverflow12(SecureRenegoOverflow, NormalHandshake12):
+    '''As with SecureRenegotOverflow, inside TLSv1.2 hello'''
+    pass
+
+
+class SecureRenegoOverflow12PFS(SecureRenegoOverflow, NormalHandshake12PFS):
+    '''As with SecureRenegoOverflow, inside TLSv1.2 PFS hello'''
+    pass
+
 
 class SecureRenegoUnderflow(SecureRenegoOverflow):
     '''Send secure renegotiation with data length lower than stated size'''

--- a/probes.py
+++ b/probes.py
@@ -227,6 +227,19 @@ class ChangeCipherSpec(NormalHandshake):
         sock.write(self.make_ccs(self.record_version))
 
 
+class ChangeCipherSpec12(ChangeCipherSpec, NormalHandshake12):
+    '''Send TLSv1.2 hello then change cipher spec'''
+
+    def __init__(self):
+        super(ChangeCipherSpec12, self).__init__()
+        self.record_version = TLSRecord.TLS1_2
+
+
+class ChangeCipherSpec12PFS(NormalHandshake12PFS, ChangeCipherSpec12):
+    '''Send PFS TLSv1.2 hello then change cipher spec'''
+    pass
+
+
 class HelloRequest(Probe):
     '''Send a hello then hello request'''
 

--- a/probes.py
+++ b/probes.py
@@ -138,34 +138,38 @@ class Probe(object):
 
 class NormalHandshake(Probe):
     '''A normal handshake'''
-    
+
+    def __init__(self):
+        super(NormalHandshake, self).__init__()
+        self.make_hello = make_hello
+
     def test(self, sock):
         logging.debug('Sending Client Hello...')
-        sock.write(make_hello())
+        sock.write(self.make_hello())
 
 
-class NormalHandshakePFS(Probe):
+class NormalHandshakePFS(NormalHandshake):
     '''Normal handshake with PFS ciphersuites'''
 
-    def test(self, sock):
-        logging.debug('Sending Client Hello...')
-        sock.write(make_pfs_hello())
+    def __init__(self):
+        super(NormalHandshakePFS, self).__init__()
+        self.make_hello = make_pfs_hello
 
 
-class NormalHandshake12(Probe):
+class NormalHandshake12(NormalHandshake):
     '''Normal TLSv1.2 handshake'''
 
-    def test(self, sock):
-        logging.debug('Sending Client Hello...')
-        sock.write(make_12_hello())
+    def __init__(self):
+        super(NormalHandshake12, self).__init__()
+        self.make_hello = make_12_hello
 
 
-class NormalHandshake12PFS(Probe):
+class NormalHandshake12PFS(NormalHandshake):
     '''Normal TLSv1.2 handshake with PFS ciphersuites'''
 
-    def test(self, sock):
-        logging.debug('Sending Client Hello...')
-        sock.write(make_12_pfs_hello())
+    def __init__(self):
+        super(NormalHandshake12PFS, self).__init__()
+        self.make_hello = make_12_pfs_hello
 
 
 class NormalHandshake12PFSw13(Probe):
@@ -188,14 +192,14 @@ class NormalHandshake12PFSw13(Probe):
         sock.write(self.make_hello())
 
 
-class DoubleClientHello(Probe):
+class DoubleClientHello(NormalHandshake):
     '''Two client hellos'''
-    
+
     def test(self, sock):
         logging.debug('Sending Client Hello...')
-        sock.write(make_hello())
+        sock.write(self.make_hello())
         logging.debug('Sending Client Hello...')
-        sock.write(make_hello())
+        sock.write(self.make_hello())
 
 
 class ChangeCipherSpec(Probe):

--- a/probes.py
+++ b/probes.py
@@ -597,6 +597,50 @@ class SplitHelloRecords(Probe):
             return result
 
 
+class SplitHelloRecords12(SplitHelloRecords):
+    '''Split the TLS1.2 hello over two records'''
+
+    def make_split_hello(self):
+        hello = ClientHelloMessage.create(TLSRecord.TLS1_2,
+                                          '01234567890123456789012345678901',
+                                          DEFAULT_12_CIPHERS)
+
+        first = hello.bytes[:10]
+        second = hello.bytes[10:]
+
+        record_one = TLSRecord.create(content_type=TLSRecord.Handshake,
+                                      version=settings['default_record_version'],
+                                      message=first)
+        record_two = TLSRecord.create(content_type=TLSRecord.Handshake,
+                                      version=settings['default_record_version'],
+                                      message=second)
+
+        #hexdump(record.bytes)
+        return record_one.bytes, record_two.bytes
+
+
+class SplitHelloRecords12PFS(SplitHelloRecords):
+    '''Split the TLS1.2 PFS hello over two records'''
+
+    def make_split_hello(self):
+        hello = ClientHelloMessage.create(TLSRecord.TLS1_2,
+                                          '01234567890123456789012345678901',
+                                          DEFAULT_PFS_CIPHERS)
+
+        first = hello.bytes[:10]
+        second = hello.bytes[10:]
+
+        record_one = TLSRecord.create(content_type=TLSRecord.Handshake,
+                                      version=settings['default_record_version'],
+                                      message=first)
+        record_two = TLSRecord.create(content_type=TLSRecord.Handshake,
+                                      version=settings['default_record_version'],
+                                      message=second)
+
+        #hexdump(record.bytes)
+        return record_one.bytes, record_two.bytes
+
+
 class SplitHelloPackets(NormalHandshake):
     '''Split the hello over two packets'''
 

--- a/probes.py
+++ b/probes.py
@@ -268,16 +268,20 @@ class HelloRequest12PFS(NormalHandshake12PFS, HelloRequest12):
     pass
 
 
-class EmptyChangeCipherSpec(Probe):
+class EmptyChangeCipherSpec(NormalHandshake):
     '''Send a hello then an empty change cipher spec'''
-    
+
+    def __init__(self):
+        super(EmptyChangeCipherSpec, self).__init__()
+        self.record_version = TLSRecord.TLS1_0
+
     def test(self, sock):
         logging.debug('Sending Client Hello...')
-        sock.write(make_hello())
+        sock.write(self.make_hello())
         logging.debug('Sending Empty ChangeCipherSpec...')
 
         record = TLSRecord.create(content_type=TLSRecord.ChangeCipherSpec,
-                                  version=TLSRecord.TLS1_0,
+                                  version=self.record_version,
                                   message='')
         sock.write(record.bytes)
 

--- a/probes.py
+++ b/probes.py
@@ -529,7 +529,7 @@ class RecordLengthUnderflow(Probe):
 
 class EmptyRecord(Probe):
     '''Send an empty record then the hello'''
-    
+
     def make_empty_record(self):
         record = TLSRecord.create(content_type=TLSRecord.Handshake,
                                   version=settings['default_record_version'],
@@ -596,16 +596,27 @@ class SplitHelloRecords(Probe):
             result = 'writeerror:%s|' % errno.errorcode[e.errno]
             return result
 
-class SplitHelloPackets(Probe):
+
+class SplitHelloPackets(NormalHandshake):
     '''Split the hello over two packets'''
-    
+
     def test(self, sock):
         logging.debug('Sending Client Hello part one...')
-        record = make_hello()
+        record = self.make_hello()
         sock.write(record[:10])
         sock.flush()
         logging.debug('Sending Client Hello part two...')
         sock.write(record[10:])
+
+
+class SplitHelloPackets12(SplitHelloPackets, NormalHandshake12):
+    '''Split the TLS1.2 hello over two packets'''
+    pass
+
+
+class SplitHelloPackets12PFS(SplitHelloPackets, NormalHandshake12PFS):
+    '''Split the TLS1.2 PFS hello over two packets'''
+    pass
 
 
 class NoCiphers(Probe):

--- a/probes.py
+++ b/probes.py
@@ -375,6 +375,19 @@ class Heartbeat(NormalHandshake):
         sock.write(self.make_heartbeat())
 
 
+class Heartbeat12(NormalHandshake12, Heartbeat):
+    '''Try to send a heartbeat message in TLSv1.2 connection'''
+
+    def __init__(self):
+        super(Heartbeat12, self).__init__()
+        self.record_version = TLSRecord.TLS1_2
+
+
+class Heartbeat12PFS(NormalHandshake12PFS, Heartbeat12):
+    '''Try to send a hearbeat message in PFS TLSv1.2 connection'''
+    pass
+
+
 class Heartbleed(Heartbeat):
     '''Try to send a heartbleed attack'''
 

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -334,6 +334,30 @@ class TestEmptyChangeCipherSpec(unittest.TestCase):
                           b'\x14\x03\x01\x00\x00'])
 
 
+class TestEmptyChangeCipherSpec12(unittest.TestCase):
+    def test_test(self):
+        probe = EmptyChangeCipherSpec12()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [MAKE_12_HELLO_EMPTY_STR,
+                          b'\x14\x03\x03\x00\x00'])
+
+
+class TestEmptyChangeCipherSpec12PFS(unittest.TestCase):
+    def test_test(self):
+        probe = EmptyChangeCipherSpec12PFS()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [MAKE_12_PFS_HELLO_EMPTY_STR,
+                          b'\x14\x03\x03\x00\x00'])
+
+
 class TestBadHandshakeMessage(unittest.TestCase):
     def test_test(self):
         probe = BadHandshakeMessage()

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -629,6 +629,49 @@ class TestSecureRenegoOverflow(unittest.TestCase):
                           b'\x0c0123456789'])
 
 
+class TestSecureRenegoOverflow12(unittest.TestCase):
+    def test_test(self):
+        probe = SecureRenegoOverflow12()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00b'
+                          b'\x01\x00\x00^'
+                          b'\x03\x03' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00&' +
+                          DEFAULT_12_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x0f'
+                          b'\xff\x01\x00\x0b'
+                          b'\x0c0123456789'])
+
+
+class TestSecureRenegoOverflow12PFS(unittest.TestCase):
+    def test_test(self):
+        probe = SecureRenegoOverflow12PFS()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.maxDiff = None
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00\x9a'
+                          b'\x01\x00\x00\x96'
+                          b'\x03\x03' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00^' +
+                          DEFAULT_PFS_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x0f'
+                          b'\xff\x01\x00\x0b'
+                          b'\x0c0123456789'])
+
+
 class TestSecureRenegoUnderflow(unittest.TestCase):
     def test_test(self):
         probe = SecureRenegoUnderflow()

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -1434,6 +1434,47 @@ class TestSecureRenegoNonEmpty(unittest.TestCase):
                           b'\x00\r\x0c012345678901'])
 
 
+class TestSecureRenegoNonEmpty12(unittest.TestCase):
+    def test_test(self):
+        probe = SecureRenegoNonEmpty12()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00d'
+                          b'\x01\x00\x00`'
+                          b'\x03\x03' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00&' +
+                          DEFAULT_12_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x11\xff\x01'
+                          b'\x00\r\x0c012345678901'])
+
+
+class TestSecureRenegoNonEmpty12PFS(unittest.TestCase):
+    def test_test(self):
+        probe = SecureRenegoNonEmpty12PFS()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.maxDiff = None
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00\x9c'
+                          b'\x01\x00\x00\x98'
+                          b'\x03\x03' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00^' +
+                          DEFAULT_PFS_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x11\xff\x01'
+                          b'\x00\r\x0c012345678901'])
+
+
 class TestSecureRenegoNull(unittest.TestCase):
     def test_test(self):
         probe = SecureRenegoNull()

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -925,6 +925,44 @@ class TestVeryHighHelloVersion(unittest.TestCase):
                           b'\x00\x00'])
 
 
+class TestVeryHighHelloVersionNew(unittest.TestCase):
+    def test_test(self):
+        probe = VeryHighHelloVersionNew()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00S'
+                          b'\x01\x00\x00O'
+                          b'\xff\xff' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00&' +
+                          DEFAULT_12_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x00'])
+
+
+class TestVeryHighHelloVersionPFS(unittest.TestCase):
+    def test_test(self):
+        probe = VeryHighHelloVersionPFS()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00\x8b'
+                          b'\x01\x00\x00\x87'
+                          b'\xff\xff' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00^' +
+                          DEFAULT_PFS_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x00'])
+
+
 class TestZeroHelloVersion(unittest.TestCase):
     def test_test(self):
         probe = ZeroHelloVersion()

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -124,6 +124,28 @@ MAKE_PFS_HELLO_EMPTY_EXT = (b"\x16\x03\x01\x00\x8b"
                             b"\x00\x00")
 
 
+MAKE_11_HELLO_EMPTY_STR = (b'\x16\x03\x01\x00S'
+                           b'\x01\x00\x00O'
+                           b'\x03\x02' +
+                           RANDOM_STR +
+                           b'\x00'
+                           b'\x00&' +
+                           DEFAULT_12_CIPHERS_STR +
+                           b'\x01\x00'
+                           b'\x00\x00')
+
+
+MAKE_11_PFS_HELLO_EMPTY_STR = (b"\x16\x03\x01\x00\x8b"
+                               b"\x01\x00\x00\x87"
+                               b"\x03\x02" +
+                               RANDOM_STR +
+                               b"\x00"
+                               b"\x00^" +
+                               DEFAULT_PFS_CIPHERS_STR +
+                               b"\x01\x00"
+                               b"\x00\x00")
+
+
 MAKE_12_HELLO_EMPTY_STR = (b'\x16\x03\x01\x00S'
                            b'\x01\x00\x00O'
                            b'\x03\x03' +
@@ -166,6 +188,28 @@ class TestNormalHandshakePFS(unittest.TestCase):
 
         self.assertEqual(sock.sent_data,
                          [MAKE_PFS_HELLO_EMPTY_EXT])
+
+
+class TestNormalHandshake11(unittest.TestCase):
+    def test_test(self):
+        probe = NormalHandshake11()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [MAKE_11_HELLO_EMPTY_STR])
+
+
+class TestNormalHandshake11PFS(unittest.TestCase):
+    def test_test(self):
+        probe = NormalHandshake11PFS()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [MAKE_11_PFS_HELLO_EMPTY_STR])
 
 
 class TestNormalHandshake12(unittest.TestCase):

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -257,6 +257,32 @@ class TestChangeCipherSpec(unittest.TestCase):
                           b'\x01'])
 
 
+class TestChangeCipherSpec12(unittest.TestCase):
+    def test_test(self):
+        probe = ChangeCipherSpec12()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [MAKE_12_HELLO_EMPTY_STR,
+                          b'\x14\x03\x03\x00\x01'
+                          b'\x01'])
+
+
+class TestChangeCipherSpec12PFS(unittest.TestCase):
+    def test_test(self):
+        probe = ChangeCipherSpec12PFS()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [MAKE_12_PFS_HELLO_EMPTY_STR,
+                          b'\x14\x03\x03\x00\x01'
+                          b'\x01'])
+
+
 class TestHelloRequest(unittest.TestCase):
     def test_test(self):
         probe = HelloRequest()

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -296,6 +296,32 @@ class TestHelloRequest(unittest.TestCase):
                           b'\x00\x00\x00\x00'])
 
 
+class TestHelloRequest12(unittest.TestCase):
+    def test_test(self):
+        probe = HelloRequest12()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [MAKE_12_HELLO_EMPTY_STR,
+                          b'\x16\x03\x03\x00\x04'
+                          b'\x00\x00\x00\x00'])
+
+
+class TestHelloRequest12PFS(unittest.TestCase):
+    def test_test(self):
+        probe = HelloRequest12PFS()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [MAKE_12_PFS_HELLO_EMPTY_STR,
+                          b'\x16\x03\x03\x00\x04'
+                          b'\x00\x00\x00\x00'])
+
+
 class TestEmptyChangeCipherSpec(unittest.TestCase):
     def test_test(self):
         probe = EmptyChangeCipherSpec()

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -1110,6 +1110,52 @@ class TestSNIWrongName(unittest.TestCase):
                           b'\x11thisisnotyourname'])
 
 
+class TestSNIWrongName12(unittest.TestCase):
+    def test_test(self):
+        probe = SNIWrongName12()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.maxDiff = None
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00m'
+                          b'\x01\x00\x00i'
+                          b'\x03\x03' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00&' +
+                          DEFAULT_12_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x1a'
+                          b'\x00\x00\x00\x16'
+                          b'\x00\x14\x00\x00'
+                          b'\x11thisisnotyourname'])
+
+
+class TestSNIWrongName12PFS(unittest.TestCase):
+    def test_test(self):
+        probe = SNIWrongName12PFS()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.maxDiff = None
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00\xa5'
+                          b'\x01\x00\x00\xa1'
+                          b'\x03\x03' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00^' +
+                          DEFAULT_PFS_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x1a'
+                          b'\x00\x00\x00\x16'
+                          b'\x00\x14\x00\x00'
+                          b'\x11thisisnotyourname'])
+
+
 class TestSNILongName(unittest.TestCase):
     def test_test(self):
         probe = SNILongName()

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -792,6 +792,45 @@ class TestZeroTLSVersion(unittest.TestCase):
                           b'\x00\x00'])
 
 
+class TestZeroTLSVersion12(unittest.TestCase):
+    def test_test(self):
+        probe = ZeroTLSVersion12()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x00\x00\x00S'
+                          b'\x01\x00\x00O'
+                          b'\x03\x03' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00&' +
+                          DEFAULT_12_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x00'])
+
+
+class TestZeroTLSVersion12PFS(unittest.TestCase):
+    def test_test(self):
+        probe = ZeroTLSVersion12PFS()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.maxDiff = None
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x00\x00\x00\x8b'
+                          b'\x01\x00\x00\x87'
+                          b'\x03\x03' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00^' +
+                          DEFAULT_PFS_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x00'])
+
+
 class TestSNIWrongName(unittest.TestCase):
     def test_test(self):
         probe = SNIWrongName()

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -540,6 +540,53 @@ class TestHeartbeat(unittest.TestCase):
                           b'\x01\x00\x04XXXX'])
 
 
+class TestHeartbeat12(unittest.TestCase):
+    def test_test(self):
+        probe = Heartbeat12()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00X'
+                          b'\x01\x00\x00T'
+                          b'\x03\x03' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00&' +
+                          DEFAULT_12_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x05'
+                          b'\x00\x0f'
+                          b'\x00\x01\x01',
+                          b'\x18\x03\x03\x00\x07'
+                          b'\x01\x00\x04XXXX'])
+
+
+class TestHeartbeat12PFS(unittest.TestCase):
+    def test_test(self):
+        probe = Heartbeat12PFS()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.maxDiff = None
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00\x90'
+                          b'\x01\x00\x00\x8c'
+                          b'\x03\x03' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00^' +
+                          DEFAULT_PFS_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x05'
+                          b'\x00\x0f'
+                          b'\x00\x01\x01',
+                          b'\x18\x03\x03\x00\x07'
+                          b'\x01\x00\x04XXXX'])
+
+
 class TestHeartbleed(unittest.TestCase):
     def test_test(self):
         probe = Heartbleed()

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -1242,6 +1242,50 @@ class TestSNIEmptyName(unittest.TestCase):
                           b'\x00\x03\x00\x00\x00'])
 
 
+class TestSNIEmptyName12(unittest.TestCase):
+    def test_test(self):
+        probe = SNIEmptyName12()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.maxDiff = None
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00\\'
+                          b'\x01\x00\x00X'
+                          b'\x03\x03' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00&' +
+                          DEFAULT_12_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\t'
+                          b'\x00\x00\x00\x05'
+                          b'\x00\x03\x00\x00\x00'])
+
+
+class TestSNIEmptyName12PFS(unittest.TestCase):
+    def test_test(self):
+        probe = SNIEmptyName12PFS()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.maxDiff = None
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00\x94'
+                          b'\x01\x00\x00\x90'
+                          b'\x03\x03' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00^' +
+                          DEFAULT_PFS_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\t'
+                          b'\x00\x00\x00\x05'
+                          b'\x00\x03\x00\x00\x00'])
+
+
 class TestSecureRenegoOverflow(unittest.TestCase):
     def test_test(self):
         probe = SecureRenegoOverflow()

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -1493,3 +1493,44 @@ class TestSecureRenegoNull(unittest.TestCase):
                           b'\x01\x00'
                           b'\x00\x04'
                           b'\xff\x01\x00\x00'])
+
+
+class TestSecureRenegoNull12(unittest.TestCase):
+    def test_test(self):
+        probe = SecureRenegoNull12()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00W'
+                          b'\x01\x00\x00S'
+                          b'\x03\x03' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00&' +
+                          DEFAULT_12_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x04'
+                          b'\xff\x01\x00\x00'])
+
+
+class TestSecureRenegoNonEmpty12PFS(unittest.TestCase):
+    def test_test(self):
+        probe = SecureRenegoNull12PFS()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.maxDiff = None
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00\x8f'
+                          b'\x01\x00\x00\x8b'
+                          b'\x03\x03' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00^' +
+                          DEFAULT_PFS_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x04'
+                          b'\xff\x01\x00\x00'])

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -1177,6 +1177,50 @@ class TestSNILongName(unittest.TestCase):
                           b'\x01\xf7\x00\x01\xf4' + b'x'*500])
 
 
+class TestSNILongName12(unittest.TestCase):
+    def test_test(self):
+        probe = SNILongName12()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.maxDiff = None
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x02P'
+                          b'\x01\x00\x02L'
+                          b'\x03\x03' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00&' +
+                          DEFAULT_12_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x01\xfd'
+                          b'\x00\x00\x01\xf9'
+                          b'\x01\xf7\x00\x01\xf4' + b'x'*500])
+
+
+class TestSNIWrongName12PFS(unittest.TestCase):
+    def test_test(self):
+        probe = SNILongName12PFS()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.maxDiff = None
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x02\x88'
+                          b'\x01\x00\x02\x84'
+                          b'\x03\x03' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00^' +
+                          DEFAULT_PFS_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x01\xfd'
+                          b'\x00\x00\x01\xf9'
+                          b'\x01\xf7\x00\x01\xf4' + b'x'*500])
+
+
 class TestSNIEmptyName(unittest.TestCase):
     def test_test(self):
         probe = SNIEmptyName()

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -676,6 +676,45 @@ class TestHighTLSVersion(unittest.TestCase):
                           b'\x00\x00'])
 
 
+class TestHighTLSVersion12(unittest.TestCase):
+    def test_test(self):
+        probe = HighTLSVersion12()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x04\x00\x00S'
+                          b'\x01\x00\x00O'
+                          b'\x03\x03' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00&' +
+                          DEFAULT_12_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x00'])
+
+
+class TestHighTLSVersion12PFS(unittest.TestCase):
+    def test_test(self):
+        probe = HighTLSVersion12PFS()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.maxDiff = None
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x04\x00\x00\x8b'
+                          b'\x01\x00\x00\x87'
+                          b'\x03\x03' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00^' +
+                          DEFAULT_PFS_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x00'])
+
+
 class TestVeryHighTLSVersion(unittest.TestCase):
     def test_test(self):
         probe = VeryHighTLSVersion()

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -378,6 +378,49 @@ class TestSplitHelloRecords(unittest.TestCase):
                           b'\x00\x00'])
 
 
+class TestSplitHelloRecords12(unittest.TestCase):
+    def test_test(self):
+        probe = SplitHelloRecords12()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00\n'
+                          b'\x01\x00\x00O'
+                          b'\x03\x03' +
+                          RANDOM_STR[:4],
+                          b'\x16\x03\x01\x00I' +
+                          RANDOM_STR[4:] +
+                          b'\x00'
+                          b'\x00&' +
+                          DEFAULT_12_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x00'])
+
+
+class TestSplitHelloRecords12PFS(unittest.TestCase):
+    def test_test(self):
+        probe = SplitHelloRecords12PFS()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.maxDiff = None
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00\n'
+                          b'\x01\x00\x00\x87'
+                          b'\x03\x03' +
+                          RANDOM_STR[:4],
+                          b'\x16\x03\x01\x00\x81' +
+                          RANDOM_STR[4:] +
+                          b'\x00'
+                          b'\x00^' +
+                          DEFAULT_PFS_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x00'])
+
+
 class TestOnlyECCipherSuites(unittest.TestCase):
     def test_test(self):
         probe = OnlyECCipherSuites()

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -610,6 +610,53 @@ class TestHeartbleed(unittest.TestCase):
                           b'\x01@\x00XXXX'])
 
 
+class TestHeartbleed12(unittest.TestCase):
+    def test_test(self):
+        probe = Heartbleed12()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00X'
+                          b'\x01\x00\x00T'
+                          b'\x03\x03' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00&' +
+                          DEFAULT_12_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x05'
+                          b'\x00\x0f'
+                          b'\x00\x01\x01',
+                          b'\x18\x03\x03\x00\x07'
+                          b'\x01@\x00XXXX'])
+
+
+class TestHeartbleed12PFS(unittest.TestCase):
+    def test_test(self):
+        probe = Heartbleed12PFS()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.maxDiff = None
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00\x90'
+                          b'\x01\x00\x00\x8c'
+                          b'\x03\x03' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00^' +
+                          DEFAULT_PFS_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x05'
+                          b'\x00\x0f'
+                          b'\x00\x01\x01',
+                          b'\x18\x03\x03\x00\x07'
+                          b'\x01@\x00XXXX'])
+
+
 class TestHighTLSVersion(unittest.TestCase):
     def test_test(self):
         probe = HighTLSVersion()

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -1046,6 +1046,30 @@ class TestEmptyRecord(unittest.TestCase):
                           MAKE_HELLO_EMPTY_EXT])
 
 
+class TestEmptyRecord12(unittest.TestCase):
+    def test_test(self):
+        probe = EmptyRecord12()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00\x00',
+                          MAKE_12_HELLO_EMPTY_STR])
+
+
+class TestEmptyRecord12PFS(unittest.TestCase):
+    def test_test(self):
+        probe = EmptyRecord12PFS()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00\x00',
+                          MAKE_12_PFS_HELLO_EMPTY_STR])
+
+
 class TestSNIWrongName(unittest.TestCase):
     def test_test(self):
         probe = SNIWrongName()

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -27,13 +27,16 @@ class MockSock(object):
     def flush(self):
         pass
 
+DEFAULT_CIPHERS_STR = b'\x00\x04\x00\x05\x00\n\x00/\x005\x00<\x00='
+
+RANDOM_STR = b'01234567890123456789012345678901'
 
 MAKE_HELLO_EMPTY_EXT = (b'\x16\x03\x01\x00;'
-                        b'\x01\x00\x007\x03\x01'
-                        b'01234567890123456789012345678901'
+                        b'\x01\x00\x007\x03\x01' +
+                        RANDOM_STR +
                         b'\x00'
-                        b'\x00\x0e'
-                        b'\x00\x04\x00\x05\x00\n\x00/\x005\x00<\x00='
+                        b'\x00\x0e' +
+                        DEFAULT_CIPHERS_STR +
                         b'\x01\x00'
                         b'\x00\x00')
 
@@ -158,12 +161,281 @@ class TestSplitHelloRecords(unittest.TestCase):
         self.assertEqual(sock.sent_data,
                          [b'\x16\x03\x01\x00\n'
                           b'\x01\x00\x007'
-                          b'\x03\x01'
-                          b'0123',
-                          b'\x16\x03\x01\x001'
-                          b'4567890123456789012345678901'
+                          b'\x03\x01' +
+                          RANDOM_STR[:4],
+                          b'\x16\x03\x01\x001' +
+                          RANDOM_STR[4:] +
                           b'\x00'
-                          b'\x00\x0e'
-                          b'\x00\x04\x00\x05\x00\n\x00/\x005\x00<\x00='
+                          b'\x00\x0e' +
+                          DEFAULT_CIPHERS_STR +
                           b'\x01\x00'
                           b'\x00\x00'])
+
+
+class TestOnlyECCipherSuites(unittest.TestCase):
+    def test_test(self):
+        probe = OnlyECCipherSuites()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b"\x16\x03\x01\x00;"
+                          b"\x01\x00\x007"
+                          b"\x03\x01" +
+                          RANDOM_STR +
+                          b"\x00"
+                          b"\x00\x0e"
+                          b"\xc0\x0c\xc0\r\xc0\x0e\xc0\x0f"
+                          b"\xc0\x13\xc0\x14\xc0'"
+                          b"\x01\x00"
+                          b"\x00\x00"])
+
+
+class TestHeartbeat(unittest.TestCase):
+    def test_test(self):
+        probe = Heartbeat()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00@'
+                          b'\x01\x00\x00<'
+                          b'\x03\x01' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00\x0e' +
+                          DEFAULT_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x05'
+                          b'\x00\x0f'
+                          b'\x00\x01\x01',
+                          b'\x18\x03\x01\x00\x07'
+                          b'\x01\x00\x04XXXX'])
+
+
+class TestHeartbleed(unittest.TestCase):
+    def test_test(self):
+        probe = Heartbleed()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00@'
+                          b'\x01\x00\x00<'
+                          b'\x03\x01' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00\x0e' +
+                          DEFAULT_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x05'
+                          b'\x00\x0f'
+                          b'\x00\x01\x01',
+                          b'\x18\x03\x01\x00\x07'
+                          b'\x01@\x00XXXX'])
+
+
+class TestHighTLSVersion(unittest.TestCase):
+    def test_test(self):
+        probe = HighTLSVersion()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x04\x00\x00;'
+                          b'\x01\x00\x007'
+                          b'\x03\x01' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00\x0e' +
+                          DEFAULT_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x00'])
+
+
+class TestVeryHighTLSVersion(unittest.TestCase):
+    def test_test(self):
+        probe = VeryHighTLSVersion()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\xff\xff\x00;'
+                          b'\x01\x00\x007'
+                          b'\x03\x01' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00\x0e' +
+                          DEFAULT_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x00'])
+
+
+class TestZeroTLSVersion(unittest.TestCase):
+    def test_test(self):
+        probe = ZeroTLSVersion()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x00\x00\x00;'
+                          b'\x01\x00\x007'
+                          b'\x03\x01' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00\x0e' +
+                          DEFAULT_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x00'])
+
+
+class TestSNIWrongName(unittest.TestCase):
+    def test_test(self):
+        probe = SNIWrongName()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00U'
+                          b'\x01\x00\x00Q'
+                          b'\x03\x01' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00\x0e' +
+                          DEFAULT_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x1a'
+                          b'\x00\x00\x00\x16'
+                          b'\x00\x14\x00\x00'
+                          b'\x11thisisnotyourname'])
+
+
+class TestSNILongName(unittest.TestCase):
+    def test_test(self):
+        probe = SNILongName()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x028'
+                          b'\x01\x00\x024'
+                          b'\x03\x01' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00\x0e' +
+                          DEFAULT_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x01\xfd'
+                          b'\x00\x00\x01\xf9'
+                          b'\x01\xf7\x00\x01\xf4' + b'x'*500])
+
+
+class TestSNIEmptyName(unittest.TestCase):
+    def test_test(self):
+        probe = SNIEmptyName()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00D'
+                          b'\x01\x00\x00@'
+                          b'\x03\x01' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00\x0e' +
+                          DEFAULT_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\t'
+                          b'\x00\x00\x00\x05'
+                          b'\x00\x03\x00\x00\x00'])
+
+
+class TestSecureRenegoOverflow(unittest.TestCase):
+    def test_test(self):
+        probe = SecureRenegoOverflow()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00J'
+                          b'\x01\x00\x00F'
+                          b'\x03\x01' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00\x0e' +
+                          DEFAULT_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x0f'
+                          b'\xff\x01\x00\x0b'
+                          b'\x0c0123456789'])
+
+
+class TestSecureRenegoUnderflow(unittest.TestCase):
+    def test_test(self):
+        probe = SecureRenegoUnderflow()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00D'
+                          b'\x01\x00\x00@'
+                          b'\x03\x01' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00\x0e' +
+                          DEFAULT_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\t'
+                          b'\xff\x01\x00\x05'
+                          b'\x00\x00\x00\x00\x00'])
+
+
+class TestSecureRenegoNonEmpty(unittest.TestCase):
+    def test_test(self):
+        probe = SecureRenegoNonEmpty()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00L'
+                          b'\x01\x00\x00H'
+                          b'\x03\x01' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00\x0e' +
+                          DEFAULT_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x11\xff\x01'
+                          b'\x00\r\x0c012345678901'])
+
+
+class TestSecureRenegoNull(unittest.TestCase):
+    def test_test(self):
+        probe = SecureRenegoNull()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00?'
+                          b'\x01\x00\x00;'
+                          b'\x03\x01' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00\x0e' +
+                          DEFAULT_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x04'
+                          b'\xff\x01\x00\x00'])

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -437,6 +437,24 @@ class TestNoCiphers(unittest.TestCase):
                           b'\x00\x00'])
 
 
+class TestNoCiphers12(unittest.TestCase):
+    def test_test(self):
+        probe = NoCiphers12()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00-'
+                          b'\x01\x00\x00)'
+                          b'\x03\x03' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00\x00'
+                          b'\x01\x00'
+                          b'\x00\x00'])
+
+
 class TestTwoInvalidPackets(unittest.TestCase):
     def test_test(self):
         probe = TwoInvalidPackets()

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -318,6 +318,31 @@ class TestSplitHelloPackets(unittest.TestCase):
                          [MAKE_HELLO_EMPTY_EXT[:10],
                           MAKE_HELLO_EMPTY_EXT[10:]])
 
+
+class TestSplitHelloPackets12(unittest.TestCase):
+    def test_test(self):
+        probe = SplitHelloPackets12()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [MAKE_12_HELLO_EMPTY_STR[:10],
+                          MAKE_12_HELLO_EMPTY_STR[10:]])
+
+
+class TestSplitHelloPackets12PFS(unittest.TestCase):
+    def test_test(self):
+        probe = SplitHelloPackets12PFS()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [MAKE_12_PFS_HELLO_EMPTY_STR[:10],
+                          MAKE_12_PFS_HELLO_EMPTY_STR[10:]])
+
+
 class TestTwoInvalidPackets(unittest.TestCase):
     def test_test(self):
         probe = TwoInvalidPackets()

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -419,6 +419,24 @@ class TestSplitHelloPackets12PFS(unittest.TestCase):
                           MAKE_12_PFS_HELLO_EMPTY_STR[10:]])
 
 
+class TestNoCiphers(unittest.TestCase):
+    def test_test(self):
+        probe = NoCiphers()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00-'
+                          b'\x01\x00\x00)'
+                          b'\x03\x01' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00\x00'
+                          b'\x01\x00'
+                          b'\x00\x00'])
+
+
 class TestTwoInvalidPackets(unittest.TestCase):
     def test_test(self):
         probe = TwoInvalidPackets()
@@ -829,6 +847,127 @@ class TestZeroTLSVersion12PFS(unittest.TestCase):
                           DEFAULT_PFS_CIPHERS_STR +
                           b'\x01\x00'
                           b'\x00\x00'])
+
+
+class TestHighHelloVersion(unittest.TestCase):
+    def test_test(self):
+        probe = HighHelloVersion()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00;'
+                          b'\x01\x00\x007'
+                          b'\x04\x00' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00\x0e' +
+                          DEFAULT_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x00'])
+
+
+class TestVeryHighHelloVersion(unittest.TestCase):
+    def test_test(self):
+        probe = VeryHighHelloVersion()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00;'
+                          b'\x01\x00\x007'
+                          b'\xff\xff' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00\x0e' +
+                          DEFAULT_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x00'])
+
+
+class TestZeroHelloVersion(unittest.TestCase):
+    def test_test(self):
+        probe = ZeroHelloVersion()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00;'
+                          b'\x01\x00\x007'
+                          b'\x00\x00' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00\x0e' +
+                          DEFAULT_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x00'])
+
+
+class TestBadContentType(unittest.TestCase):
+    def test_test(self):
+        probe = BadContentType()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x11\x03\x01\x00;'
+                          b'\x01\x00\x007'
+                          b'\x03\x01' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00\x0e' +
+                          DEFAULT_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x00'])
+
+
+class TestRecordLengthOverflow(unittest.TestCase):
+    def test_test(self):
+        probe = RecordLengthOverflow()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00\x01'
+                          b'\x01'])
+
+
+class TestRecordLengthUnderflow(unittest.TestCase):
+    def test_test(self):
+        probe = RecordLengthUnderflow()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(len(sock.sent_data[0]), 65540)
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\xff\xff'
+                          b'\x01\x00\x007'
+                          b'\x03\x01' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00\x0e' +
+                          DEFAULT_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x00' +
+                          b'\x00' * (65540 - 64)])
+
+
+class TestEmptyRecord(unittest.TestCase):
+    def test_test(self):
+        probe = EmptyRecord()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00\x00',
+                          MAKE_HELLO_EMPTY_EXT])
 
 
 class TestSNIWrongName(unittest.TestCase):

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -734,6 +734,45 @@ class TestVeryHighTLSVersion(unittest.TestCase):
                           b'\x00\x00'])
 
 
+class TestVeryHighTLSVersion12(unittest.TestCase):
+    def test_test(self):
+        probe = VeryHighTLSVersion12()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\xff\xff\x00S'
+                          b'\x01\x00\x00O'
+                          b'\x03\x03' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00&' +
+                          DEFAULT_12_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x00'])
+
+
+class TestVeryHighTLSVersion12PFS(unittest.TestCase):
+    def test_test(self):
+        probe = VeryHighTLSVersion12PFS()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.maxDiff = None
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\xff\xff\x00\x8b'
+                          b'\x01\x00\x00\x87'
+                          b'\x03\x03' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00^' +
+                          DEFAULT_PFS_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x00'])
+
+
 class TestZeroTLSVersion(unittest.TestCase):
     def test_test(self):
         probe = ZeroTLSVersion()

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -29,7 +29,79 @@ class MockSock(object):
 
 DEFAULT_CIPHERS_STR = b'\x00\x04\x00\x05\x00\n\x00/\x005\x00<\x00='
 
+
+DEFAULT_PFS_CIPHERS_STR = (b"\xc0,"
+                           b"\xc0+"
+                           b"\xc0$"
+                           b"\xc0#"
+                           b"\xc0\n"
+                           b"\xc0\t"
+                           b"\xc00"
+                           b"\xc0/"
+                           b"\xc0("
+                           b"\xc0'"
+                           b"\xc0\x14"
+                           b"\xc0\x13"
+                           b"\x00\x9f"
+                           b"\x00\x9e"
+                           b"\x00k"
+                           b"\x00g"
+                           b"\x009"
+                           b"\x003"
+                           b"\xcc\xa9"
+                           b"\xcc\xa2"
+                           b"\xcc\x14"
+                           b"\xcc\xa8"
+                           b"\xcc\xa1"
+                           b"\xcc\x13"
+                           b"\xcc\xaa"
+                           b"\xcc\xa3"
+                           b"\xcc\x15"
+                           b"\xc0\xad"
+                           b"\xc0\xac"
+                           b"\xc0\xaf"
+                           b"\xc0\xae"
+                           b"\xc0\x9f"
+                           b"\xc0\x9e"
+                           b"\xc0\xa3"
+                           b"\xc0\xa2"
+                           b"\xc0\x07"
+                           b"\xc0\x08"
+                           b"\xc0s"
+                           b"\xc0H"
+                           b"\xc0\x11"
+                           b"\xc0\x12"
+                           b"\xc0w"
+                           b"\xc0M"
+                           b"\x00\x88"
+                           b"\x00\x16"
+                           b"\x00\x9a"
+                           b"\xc0D")
+
+
+DEFAULT_12_CIPHERS_STR = (b'\x00\x04'
+                          b'\x00\x05'
+                          b'\x00\n'
+                          b'\x00/'
+                          b'\x005'
+                          b'\x00<'
+                          b'\x00='
+                          b'\x00\x9c'
+                          b'\x00\x9d'
+                          b'\xcc\xa0'
+                          b'\xc0\x9c'
+                          b'\xc0\x9d'
+                          b'\xc0\xa0'
+                          b'\xc0\xa1'
+                          b'\x00A'
+                          b'\x00\x84'
+                          b'\x00\xba'
+                          b'\xc0<'
+                          b'\x00\x96')
+
+
 RANDOM_STR = b'01234567890123456789012345678901'
+
 
 MAKE_HELLO_EMPTY_EXT = (b'\x16\x03\x01\x00;'
                         b'\x01\x00\x007\x03\x01' +
@@ -41,6 +113,39 @@ MAKE_HELLO_EMPTY_EXT = (b'\x16\x03\x01\x00;'
                         b'\x00\x00')
 
 
+MAKE_PFS_HELLO_EMPTY_EXT = (b"\x16\x03\x01\x00\x8b"
+                            b"\x01\x00\x00\x87"
+                            b"\x03\x01" +
+                            RANDOM_STR +
+                            b"\x00"
+                            b"\x00^" +
+                            DEFAULT_PFS_CIPHERS_STR +
+                            b"\x01\x00"
+                            b"\x00\x00")
+
+
+MAKE_12_HELLO_EMPTY_STR = (b'\x16\x03\x01\x00S'
+                           b'\x01\x00\x00O'
+                           b'\x03\x03' +
+                           RANDOM_STR +
+                           b'\x00'
+                           b'\x00&' +
+                           DEFAULT_12_CIPHERS_STR +
+                           b'\x01\x00'
+                           b'\x00\x00')
+
+
+MAKE_12_PFS_HELLO_EMPTY_STR = (b"\x16\x03\x01\x00\x8b"
+                               b"\x01\x00\x00\x87"
+                               b"\x03\x03" +
+                               RANDOM_STR +
+                               b"\x00"
+                               b"\x00^" +
+                               DEFAULT_PFS_CIPHERS_STR +
+                               b"\x01\x00"
+                               b"\x00\x00")
+
+
 class TestNormalHandshake(unittest.TestCase):
     def test_test(self):
         probe = NormalHandshake()
@@ -50,6 +155,58 @@ class TestNormalHandshake(unittest.TestCase):
 
         self.assertEqual(sock.sent_data,
                          [MAKE_HELLO_EMPTY_EXT])
+
+
+class TestNormalHandshakePFS(unittest.TestCase):
+    def test_test(self):
+        probe = NormalHandshakePFS()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [MAKE_PFS_HELLO_EMPTY_EXT])
+
+
+class TestNormalHandshake12(unittest.TestCase):
+    def test_test(self):
+        probe = NormalHandshake12()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [MAKE_12_HELLO_EMPTY_STR])
+
+
+class TestNormalHandshake12PFS(unittest.TestCase):
+    def test_test(self):
+        probe = NormalHandshake12PFS()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [MAKE_12_PFS_HELLO_EMPTY_STR])
+
+
+class Test(unittest.TestCase):
+    def test_test(self):
+        probe = NormalHandshake12PFSw13()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b"\x16\x03\x01\x00\x8b"
+                          b"\x01\x00\x00\x87"
+                          b"\x03\x04" +
+                          RANDOM_STR +
+                          b"\x00"
+                          b"\x00^" +
+                          DEFAULT_PFS_CIPHERS_STR +
+                          b"\x01\x00"
+                          b"\x00\x00"])
 
 
 class TestDoubleClientHello(unittest.TestCase):

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -868,6 +868,44 @@ class TestHighHelloVersion(unittest.TestCase):
                           b'\x00\x00'])
 
 
+class TestHighHelloVersionNew(unittest.TestCase):
+    def test_test(self):
+        probe = HighHelloVersionNew()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00S'
+                          b'\x01\x00\x00O'
+                          b'\x04\x00' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00&' +
+                          DEFAULT_12_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x00'])
+
+
+class TestHighHelloVersionPFS(unittest.TestCase):
+    def test_test(self):
+        probe = HighHelloVersionPFS()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00\x8b'
+                          b'\x01\x00\x00\x87'
+                          b'\x04\x00' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00^' +
+                          DEFAULT_PFS_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x00'])
+
+
 class TestVeryHighHelloVersion(unittest.TestCase):
     def test_test(self):
         probe = VeryHighHelloVersion()

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -220,6 +220,30 @@ class TestDoubleClientHello(unittest.TestCase):
                          [MAKE_HELLO_EMPTY_EXT, MAKE_HELLO_EMPTY_EXT])
 
 
+class TestDoubleClientHello12(unittest.TestCase):
+    def test_test(self):
+        probe = DoubleClientHello12()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [MAKE_12_HELLO_EMPTY_STR,
+                          MAKE_12_HELLO_EMPTY_STR])
+
+
+class TestDoubleClientHello12PFS(unittest.TestCase):
+    def test_test(self):
+        probe = DoubleClientHello12PFS()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [MAKE_12_PFS_HELLO_EMPTY_STR,
+                          MAKE_12_PFS_HELLO_EMPTY_STR])
+
+
 class TestChangeCipherSpec(unittest.TestCase):
     def test_test(self):
         probe = ChangeCipherSpec()

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -1371,6 +1371,49 @@ class TestSecureRenegoUnderflow(unittest.TestCase):
                           b'\x00\x00\x00\x00\x00'])
 
 
+class TestSecureRenegoUnderflow12(unittest.TestCase):
+    def test_test(self):
+        probe = SecureRenegoUnderflow12()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00\\'
+                          b'\x01\x00\x00X'
+                          b'\x03\x03' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00&' +
+                          DEFAULT_12_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\t'
+                          b'\xff\x01\x00\x05'
+                          b'\x00\x00\x00\x00\x00'])
+
+
+class TestSecureRenegoUnderflow12PFS(unittest.TestCase):
+    def test_test(self):
+        probe = SecureRenegoUnderflow12PFS()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.maxDiff = None
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00\x94'
+                          b'\x01\x00\x00\x90'
+                          b'\x03\x03' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00^' +
+                          DEFAULT_PFS_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\t'
+                          b'\xff\x01\x00\x05'
+                          b'\x00\x00\x00\x00\x00'])
+
+
 class TestSecureRenegoNonEmpty(unittest.TestCase):
     def test_test(self):
         probe = SecureRenegoNonEmpty()

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -1,0 +1,149 @@
+import sys
+import os
+# Ensure we can see the pytls/tls subdir for the pytls submodule
+sys.path.insert(1, os.path.join(os.path.dirname(__file__), '..', 'pytls'))
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+try:
+    import mock
+    from mock import call
+except ImportError:
+    import unittest.mock as mock
+    from unittest.mock import call
+
+from probes import *
+
+
+class MockSock(object):
+    def __init__(self):
+        self.sent_data = []
+
+    def write(self, data):
+        self.sent_data.append(data)
+
+    def flush(self):
+        pass
+
+
+MAKE_HELLO_EMPTY_EXT = (b'\x16\x03\x01\x00;'
+                        b'\x01\x00\x007\x03\x01'
+                        b'01234567890123456789012345678901'
+                        b'\x00'
+                        b'\x00\x0e'
+                        b'\x00\x04\x00\x05\x00\n\x00/\x005\x00<\x00='
+                        b'\x01\x00'
+                        b'\x00\x00')
+
+
+class TestNormalHandshake(unittest.TestCase):
+    def test_test(self):
+        probe = NormalHandshake()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [MAKE_HELLO_EMPTY_EXT])
+
+
+class TestDoubleClientHello(unittest.TestCase):
+    def test_test(self):
+        probe = DoubleClientHello()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [MAKE_HELLO_EMPTY_EXT, MAKE_HELLO_EMPTY_EXT])
+
+
+class TestChangeCipherSpec(unittest.TestCase):
+    def test_test(self):
+        probe = ChangeCipherSpec()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [MAKE_HELLO_EMPTY_EXT,
+                          b'\x14\x03\x01\x00\x01'
+                          b'\x01'])
+
+
+class TestHelloRequest(unittest.TestCase):
+    def test_test(self):
+        probe = HelloRequest()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [MAKE_HELLO_EMPTY_EXT,
+                          b'\x16\x03\x01\x00\x04'
+                          b'\x00\x00\x00\x00'])
+
+
+class TestEmptyChangeCipherSpec(unittest.TestCase):
+    def test_test(self):
+        probe = EmptyChangeCipherSpec()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [MAKE_HELLO_EMPTY_EXT,
+                          b'\x14\x03\x01\x00\x00'])
+
+
+class TestBadHandshakeMessage(unittest.TestCase):
+    def test_test(self):
+        probe = BadHandshakeMessage()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [MAKE_HELLO_EMPTY_EXT,
+                          b'\x16\x03\x01\x00\t'
+                          b'Something'])
+
+
+class TestEmptyRecord(unittest.TestCase):
+    def test_test(self):
+        probe = EmptyRecord()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00\x00',
+                          MAKE_HELLO_EMPTY_EXT])
+
+
+class TestSplitHelloPackets(unittest.TestCase):
+    def test_test(self):
+        probe = SplitHelloPackets()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [MAKE_HELLO_EMPTY_EXT[:10],
+                          MAKE_HELLO_EMPTY_EXT[10:]])
+
+class TestSplitHelloRecords(unittest.TestCase):
+    def test_test(self):
+        probe = SplitHelloRecords()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        # XXX this is broken, but can't change it as it would invalidate
+        # probes
+        self.assertEqual(bytes(sock.sent_data[0])[:32],
+                         b'<tls.record.TLSRecord object at ')
+        self.assertEqual(bytes(sock.sent_data[1])[:32],
+                         b'<tls.record.TLSRecord object at ')


### PR DESCRIPTION
add probes with ephemeral key exchanges, and TLSv1.1 and TLSv1.2 native probes

fix a problem with SplitHelloRecords test

add test coverage for probes

start of work towards #14, needs fingerprints to fix it fully
