### PR TITLE
RFC6066 extensions - TLSv1.2 PFS edition

### DIFF
--- a/prober.py
+++ b/prober.py
@@ -123,6 +123,8 @@ probes = [
     TrustedCAUnderflow12(),
     TrustedCAUnderflow12PFS(),
     TruncatedHMACNotNull(),
+    TruncatedHMACNotNull12(),
+    TruncatedHMACNotNull12PFS(),
     OCSPNull(),
     OCSPOverflow(),
     OCSPUnderflow(),

--- a/prober.py
+++ b/prober.py
@@ -126,6 +126,8 @@ probes = [
     TruncatedHMACNotNull12(),
     TruncatedHMACNotNull12PFS(),
     OCSPNull(),
+    OCSPNull12(),
+    OCSPNull12PFS(),
     OCSPOverflow(),
     OCSPUnderflow(),
     DoubleExtension()

--- a/prober.py
+++ b/prober.py
@@ -117,6 +117,8 @@ probes = [
     TrustedCANull12(),
     TrustedCANull12PFS(),
     TrustedCAOverflow(),
+    TrustedCAOverflow12(),
+    TrustedCAOverflow12PFS(),
     TrustedCAUnderflow(),
     TruncatedHMACNotNull(),
     OCSPNull(),

--- a/prober.py
+++ b/prober.py
@@ -114,6 +114,8 @@ probes = [
     ClientCertURLsNotNull12(),
     ClientCertURLsNotNull12PFS(),
     TrustedCANull(),
+    TrustedCANull12(),
+    TrustedCANull12PFS(),
     TrustedCAOverflow(),
     TrustedCAUnderflow(),
     TruncatedHMACNotNull(),

--- a/prober.py
+++ b/prober.py
@@ -111,6 +111,8 @@ probes = [
     MaxFragmentInvalid12(),
     MaxFragmentInvalid12PFS(),
     ClientCertURLsNotNull(),
+    ClientCertURLsNotNull12(),
+    ClientCertURLsNotNull12PFS(),
     TrustedCANull(),
     TrustedCAOverflow(),
     TrustedCAUnderflow(),

--- a/prober.py
+++ b/prober.py
@@ -132,6 +132,8 @@ probes = [
     OCSPOverflow12(),
     OCSPOverflow12PFS(),
     OCSPUnderflow(),
+    OCSPUnderflow12(),
+    OCSPUnderflow12PFS(),
     DoubleExtension()
 ]
 

--- a/prober.py
+++ b/prober.py
@@ -120,6 +120,8 @@ probes = [
     TrustedCAOverflow12(),
     TrustedCAOverflow12PFS(),
     TrustedCAUnderflow(),
+    TrustedCAUnderflow12(),
+    TrustedCAUnderflow12PFS(),
     TruncatedHMACNotNull(),
     OCSPNull(),
     OCSPOverflow(),

--- a/prober.py
+++ b/prober.py
@@ -108,6 +108,8 @@ probes = [
     MaxFragmentNull12(),
     MaxFragmentNull12PFS(),
     MaxFragmentInvalid(),
+    MaxFragmentInvalid12(),
+    MaxFragmentInvalid12PFS(),
     ClientCertURLsNotNull(),
     TrustedCANull(),
     TrustedCAOverflow(),

--- a/prober.py
+++ b/prober.py
@@ -129,6 +129,8 @@ probes = [
     OCSPNull12(),
     OCSPNull12PFS(),
     OCSPOverflow(),
+    OCSPOverflow12(),
+    OCSPOverflow12PFS(),
     OCSPUnderflow(),
     DoubleExtension()
 ]

--- a/prober.py
+++ b/prober.py
@@ -105,6 +105,8 @@ probes = [
     SecureRenegoNull12(),
     SecureRenegoNull12PFS(),
     MaxFragmentNull(),
+    MaxFragmentNull12(),
+    MaxFragmentNull12PFS(),
     MaxFragmentInvalid(),
     ClientCertURLsNotNull(),
     TrustedCANull(),

--- a/prober.py
+++ b/prober.py
@@ -134,7 +134,9 @@ probes = [
     OCSPUnderflow(),
     OCSPUnderflow12(),
     OCSPUnderflow12PFS(),
-    DoubleExtension()
+    DoubleExtension(),
+    DoubleExtension12(),
+    DoubleExtension12PFS()
 ]
 
 def probe(ipaddress, port, starttls, specified_probe):

--- a/probes.py
+++ b/probes.py
@@ -1176,6 +1176,16 @@ class ClientCertURLsNotNull(NormalHandshake):
         sock.write(self.make_cert_urls_hello('\x08\x00'))
 
 
+class ClientCertURLsNotNull12(ClientCertURLsNotNull, NormalHandshake12):
+    '''As with ClientCertURLsNotNull, but in TLSv1.2 hello'''
+    pass
+
+
+class ClientCertURLsNotNull12PFS(ClientCertURLsNotNull, NormalHandshake12PFS):
+    '''As with ClientCertURLsNotNull, but in PFS TLSv1.2 hello'''
+    pass
+
+
 class TrustedCANull(NormalHandshake):
     '''Send trusted CA keys extension with completely empty payload'''
 

--- a/probes.py
+++ b/probes.py
@@ -1149,6 +1149,16 @@ class MaxFragmentInvalid(MaxFragmentNull):
         sock.write(self.make_fragment_hello('\x08'))
 
 
+class MaxFragmentInvalid12(MaxFragmentInvalid, NormalHandshake12):
+    '''As with MaxFragmentInvalid, but in TLSv1.2 hello'''
+    pass
+
+
+class MaxFragmentInvalid12PFS(MaxFragmentInvalid, NormalHandshake12PFS):
+    '''As with MaxFragmentInvalid, but in PFS TLSv1.2 hello'''
+    pass
+
+
 class ClientCertURLsNotNull(NormalHandshake):
     '''Send client certificate URL indication extension that is not empty'''
 

--- a/probes.py
+++ b/probes.py
@@ -1249,6 +1249,16 @@ class TrustedCAUnderflow(TrustedCANull):
         sock.write(self.make_trusted_ca_hello(ext_data))
 
 
+class TrustedCAUnderflow12(TrustedCAUnderflow, NormalHandshake12):
+    '''As with TrustedCAUnderflow but in TLSv1.2 hello'''
+    pass
+
+
+class TrustedCAUnderflow12PFS(TrustedCAUnderflow, NormalHandshake12PFS):
+    '''As with TrustedCAUnderflow but in PFS TLSv1.2 hello'''
+    pass
+
+
 class TruncatedHMACNotNull(NormalHandshake):
     '''Send a truncated HMAC extension with a non empty payload'''
 

--- a/probes.py
+++ b/probes.py
@@ -1372,3 +1372,13 @@ class DoubleExtension(NormalHandshake):
         # correct Client Hello messages must not contain two extensions
         # of the same type
         sock.write(self.make_double_ext_hello())
+
+
+class DoubleExtension12(DoubleExtension, NormalHandshake12):
+    '''Duplicate secure renegotiation extension in TLSv1.2 hello'''
+    pass
+
+
+class DoubleExtension12PFS(DoubleExtension, NormalHandshake12PFS):
+    '''Duplicate secure renegotiation extension in PFS TLSv1.2 hello'''
+    pass

--- a/probes.py
+++ b/probes.py
@@ -1326,6 +1326,16 @@ class OCSPOverflow(OCSPNull):
         sock.write(self.make_ocsp_hello('\x01\x00\x00\x00'))
 
 
+class OCSPOverflow12(OCSPOverflow, NormalHandshake12):
+    '''As with OCSPOverflow but in TLSv1.2 hello'''
+    pass
+
+
+class OCSPOverflow12PFS(OCSPOverflow, NormalHandshake12PFS):
+    '''As with OCSPOverflow but in PFS TLSv1.2 hello'''
+    pass
+
+
 class OCSPUnderflow(OCSPNull):
     '''Send status request ext larger than the length inside indicate'''
 

--- a/probes.py
+++ b/probes.py
@@ -1130,6 +1130,16 @@ class MaxFragmentNull(NormalHandshake):
         sock.write(self.make_fragment_hello(''))
 
 
+class MaxFragmentNull12(MaxFragmentNull, NormalHandshake12):
+    '''As with MaxFragmentNull, but in TLSv1.2 hello'''
+    pass
+
+
+class MaxFragmentNull12PFS(MaxFragmentNull, NormalHandshake12PFS):
+    '''As with MaxFragmentNull, but in PFS TLSv1.2 hello'''
+    pass
+
+
 class MaxFragmentInvalid(MaxFragmentNull):
     '''Send maximum fragment length extension with invalid value'''
 

--- a/probes.py
+++ b/probes.py
@@ -1306,6 +1306,16 @@ class OCSPNull(NormalHandshake):
         sock.write(self.make_ocsp_hello(''))
 
 
+class OCSPNull12(OCSPNull, NormalHandshake12):
+    '''As with OCSPNull but in TLSv1.2 hello'''
+    pass
+
+
+class OCSPNull12PFS(OCSPNull, NormalHandshake12PFS):
+    '''As with OCSPNull but in PFS TLSv1.2 hello'''
+    pass
+
+
 class OCSPOverflow(OCSPNull):
     '''Send status request ext smaller than the length inside indicates'''
 

--- a/probes.py
+++ b/probes.py
@@ -1277,6 +1277,16 @@ class TruncatedHMACNotNull(NormalHandshake):
         sock.write(self.make_truncated_hmac_hello('\x0c'))
 
 
+class TruncatedHMACNotNull12(TruncatedHMACNotNull, NormalHandshake12):
+    '''As with TruncatedHMACNotNull but in TLSv1.2 hello'''
+    pass
+
+
+class TruncatedHMACNotNull12PFS(TruncatedHMACNotNull, NormalHandshake12PFS):
+    '''As with TruncatedHMACNotNull but in PFS TLSv1.2 hello'''
+    pass
+
+
 class OCSPNull(NormalHandshake):
     '''Send status request extension with empty payload'''
 

--- a/probes.py
+++ b/probes.py
@@ -1224,6 +1224,16 @@ class TrustedCAOverflow(TrustedCANull):
         sock.write(self.make_trusted_ca_hello('\x00\x15'))
 
 
+class TrustedCAOverflow12(TrustedCAOverflow, NormalHandshake12):
+    '''As with TrustedCAOverflow but in TLSv1.2 hello'''
+    pass
+
+
+class TrustedCAOverflow12PFS(TrustedCAOverflow, NormalHandshake12PFS):
+    '''As with TrustedCAOverflow but in PFS TLSv1.2 hello'''
+    pass
+
+
 class TrustedCAUnderflow(TrustedCANull):
     '''Send trusted CA keys extension larger than length inside indicates'''
 

--- a/probes.py
+++ b/probes.py
@@ -1112,29 +1112,22 @@ class SecureRenegoNull12PFS(SecureRenegoNull, NormalHandshake12PFS):
     pass
 
 
-class MaxFragmentNull(Probe):
+class MaxFragmentNull(NormalHandshake):
     '''Send maximum fragment length extension that is completely empty'''
 
-    def make_hello(self, payload):
+    def make_fragment_hello(self, payload):
         max_fragment = Extension.create(
             extension_type=Extension.MaxFragmentLength,
             data=payload)
 
-        hello = ClientHelloMessage.create(settings['default_hello_version'],
-                                          '01234567890123456789012345678901',
-                                          DEFAULT_CIPHERS,
-                                          extensions=[max_fragment])
+        record = self.make_hello([max_fragment])
 
-        record = TLSRecord.create(content_type=TLSRecord.Handshake,
-                                  version=settings['default_record_version'],
-                                  message=hello.bytes)
-
-        return record.bytes
+        return record
 
     def test(self, sock):
         logging.debug('Sending Client Hello...')
         # normal extension needs a single byte value, don't provide it
-        sock.write(self.make_hello(''))
+        sock.write(self.make_fragment_hello(''))
 
 
 class MaxFragmentInvalid(MaxFragmentNull):
@@ -1143,57 +1136,41 @@ class MaxFragmentInvalid(MaxFragmentNull):
     def test(self, sock):
         logging.debug('Sending Client Hello...')
         # valid values are between 1 and 4 inclusive
-        sock.write(self.make_hello('\x08'))
+        sock.write(self.make_fragment_hello('\x08'))
 
 
-class ClientCertURLsNotNull(Probe):
+class ClientCertURLsNotNull(NormalHandshake):
     '''Send client certificate URL indication extension that is not empty'''
 
-    def make_hello(self, payload):
+    def make_cert_urls_hello(self, payload):
         client_cert_url_ext = Extension.create(
             extension_type=Extension.ClientCertificateUrl,
             data=payload)
 
-        hello = ClientHelloMessage.create(settings['default_hello_version'],
-                                          '01234567890123456789012345678901',
-                                          DEFAULT_CIPHERS,
-                                          extensions=[client_cert_url_ext])
-
-        record = TLSRecord.create(content_type=TLSRecord.Handshake,
-                                  version=settings['default_record_version'],
-                                  message=hello.bytes)
-
-        return record.bytes
+        record = self.make_hello([client_cert_url_ext])
+        return record
 
     def test(self, sock):
         logging.debug('Sending Client Hello...')
         # correctly formatted does not include any data
-        sock.write(self.make_hello('\x08\x00'))
+        sock.write(self.make_cert_urls_hello('\x08\x00'))
 
 
-class TrustedCANull(Probe):
+class TrustedCANull(NormalHandshake):
     '''Send trusted CA keys extension with completely empty payload'''
 
-    def make_hello(self, payload):
+    def make_trusted_ca_hello(self, payload):
         trusted_ca_ext = Extension.create(
             extension_type=Extension.TrustedCAKeys,
             data=payload)
 
-        hello = ClientHelloMessage.create(settings['default_hello_version'],
-                                          '01234567890123456789012345678901',
-                                          DEFAULT_CIPHERS,
-                                          extensions=[trusted_ca_ext])
-
-        record = TLSRecord.create(content_type=TLSRecord.Handshake,
-                                  version=settings['default_record_version'],
-                                  message=hello.bytes)
-
-        return record.bytes
+        record = self.make_hello([trusted_ca_ext])
+        return record
 
     def test(self, sock):
         logging.debug('Sending Client Hello...')
         # normal formatting is a complex structure
-        sock.write(self.make_hello(''))
+        sock.write(self.make_trusted_ca_hello(''))
 
 
 class TrustedCAOverflow(TrustedCANull):
@@ -1204,7 +1181,7 @@ class TrustedCAOverflow(TrustedCANull):
         # in a normal structure, the first two bytes are the overall length
         # of list with extension data
         # a typical payload includes type (1B) and sha1 hash (20B)
-        sock.write(self.make_hello('\x00\x15'))
+        sock.write(self.make_trusted_ca_hello('\x00\x15'))
 
 
 class TrustedCAUnderflow(TrustedCANull):
@@ -1219,55 +1196,44 @@ class TrustedCAUnderflow(TrustedCANull):
         # add null byte at end to cause the underflow
         ext_data = struct.pack('!H', len(authority)) + authority + '\x00'
 
-        sock.write(self.make_hello(ext_data))
+        sock.write(self.make_trusted_ca_hello(ext_data))
 
 
-class TruncatedHMACNotNull(Probe):
+class TruncatedHMACNotNull(NormalHandshake):
     '''Send a truncated HMAC extension with a non empty payload'''
 
-    def make_hello(self, payload):
+    def make_truncated_hmac_hello(self, payload):
         truncated_hmac = Extension.create(
             extension_type=Extension.TruncateHMAC,
             data=payload)
-        hello = ClientHelloMessage.create(settings['default_hello_version'],
-                                          '01234567890123456789012345678901',
-                                          DEFAULT_CIPHERS,
-                                          extensions=[truncated_hmac])
 
-        record = TLSRecord.create(content_type=TLSRecord.Handshake,
-                                  version=settings['default_record_version'],
-                                  message=hello.bytes)
+        record = self.make_hello([truncated_hmac])
 
-        return record.bytes
+        return record
 
     def test(self, sock):
         logging.debug('Sending Client Hello...')
         # properly formatted extension has no data at all
-        sock.write(self.make_hello('\x0c'))
+        sock.write(self.make_truncated_hmac_hello('\x0c'))
 
-class OCSPNull(Probe):
+
+class OCSPNull(NormalHandshake):
     '''Send status request extension with empty payload'''
 
-    def make_hello(self, payload):
+    def make_ocsp_hello(self, payload):
         status_request = Extension.create(
             extension_type=Extension.StatusRequest,
             data=payload)
-        hello = ClientHelloMessage.create(settings['default_hello_version'],
-                                          '01234567890123456789012345678901',
-                                          DEFAULT_CIPHERS,
-                                          extensions=[status_request])
 
-        record = TLSRecord.create(content_type=TLSRecord.Handshake,
-                                  version=settings['default_record_version'],
-                                  message=hello.bytes)
+        record = self.make_hello([status_request])
 
-        return record.bytes
+        return record
 
     def test(self, sock):
         logging.debug('Sending Client Hello...')
         # normally the status request is a complex structure, don't include
         # it
-        sock.write(self.make_hello(''))
+        sock.write(self.make_ocsp_hello(''))
 
 
 class OCSPOverflow(OCSPNull):
@@ -1277,7 +1243,7 @@ class OCSPOverflow(OCSPNull):
         logging.debug('Sending Client Hello...')
         # the request has three fields - type (one byte) and two arrays
         # with 2 byte long headers, truncate the second length header
-        sock.write(self.make_hello('\x01\x00\x00\x00'))
+        sock.write(self.make_ocsp_hello('\x01\x00\x00\x00'))
 
 
 class OCSPUnderflow(OCSPNull):
@@ -1286,30 +1252,23 @@ class OCSPUnderflow(OCSPNull):
     def test(self, sock):
         logging.debug('Sending Client Hello...')
         # correctly formed request, two extra zero bytes
-        sock.write(self.make_hello('\x01' + '\x00' * 6))
+        sock.write(self.make_ocsp_hello('\x01' + '\x00' * 6))
 
 
-class DoubleExtension(Probe):
+class DoubleExtension(NormalHandshake):
     '''Duplicate secure renegotiation extension'''
 
-    def make_hello(self):
+    def make_double_ext_hello(self):
         secure_renego = Extension.create(
             extension_type=Extension.RenegotiationInfo,
             data='\x00')
-        hello = ClientHelloMessage.create(settings['default_hello_version'],
-                                          '01234567890123456789012345678901',
-                                          DEFAULT_CIPHERS,
-                                          extensions=[secure_renego,
-                                                      secure_renego])
 
-        record = TLSRecord.create(content_type=TLSRecord.Handshake,
-                                  version=settings['default_record_version'],
-                                  message=hello.bytes)
-
-        return record.bytes
+        record = self.make_hello([secure_renego,
+                                  secure_renego])
+        return record
 
     def test(self, sock):
         logging.debug('Sending Client Hello...')
         # correct Client Hello messages must not contain two extensions
         # of the same type
-        sock.write(self.make_hello())
+        sock.write(self.make_double_ext_hello())

--- a/probes.py
+++ b/probes.py
@@ -1345,6 +1345,16 @@ class OCSPUnderflow(OCSPNull):
         sock.write(self.make_ocsp_hello('\x01' + '\x00' * 6))
 
 
+class OCSPUnderflow12(OCSPUnderflow, NormalHandshake12):
+    '''As with OCSPUnderflow but in TLSv1.2 hello'''
+    pass
+
+
+class OCSPUnderflow12PFS(OCSPUnderflow, NormalHandshake12PFS):
+    '''As with OCSPUnderflow but in PFS TLSv1.2 hello'''
+    pass
+
+
 class DoubleExtension(NormalHandshake):
     '''Duplicate secure renegotiation extension'''
 

--- a/probes.py
+++ b/probes.py
@@ -1203,6 +1203,16 @@ class TrustedCANull(NormalHandshake):
         sock.write(self.make_trusted_ca_hello(''))
 
 
+class TrustedCANull12(TrustedCANull, NormalHandshake12):
+    '''As with TrustedCANull but in TLSv1.2 hello'''
+    pass
+
+
+class TrustedCANull12PFS(TrustedCANull, NormalHandshake12PFS):
+    '''As with TrustedCANull, but in PFS TLSv1.2 hello'''
+    pass
+
+
 class TrustedCAOverflow(TrustedCANull):
     '''Send trusted CA keys extension smaller than length inside indicates'''
 

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -1726,6 +1726,49 @@ class TestClientCertURLsNotNull(unittest.TestCase):
                           b'\x08\x00'])
 
 
+class TestClientCertURLsNotNull12(unittest.TestCase):
+    def test_test(self):
+        probe = ClientCertURLsNotNull12()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00Y'
+                          b'\x01\x00\x00U'
+                          b'\x03\x03' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00&' +
+                          DEFAULT_12_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x06'
+                          b'\x00\x02\x00\x02'
+                          b'\x08\x00'])
+
+
+class TestClientCertURLsNotNull12PFS(unittest.TestCase):
+    def test_test(self):
+        probe = ClientCertURLsNotNull12PFS()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.maxDiff = None
+        self.assertEqual(sock.sent_data,
+                         [b"\x16\x03\x01\x00\x91"
+                          b"\x01\x00\x00\x8d"
+                          b"\x03\x03" +
+                          RANDOM_STR +
+                          b"\x00"
+                          b"\x00^" +
+                          DEFAULT_PFS_CIPHERS_STR +
+                          b"\x01\x00"
+                          b'\x00\x06'
+                          b'\x00\x02\x00\x02'
+                          b'\x08\x00'])
+
+
 class TestTrustedCANull(unittest.TestCase):
     def test_test(self):
         probe = TrustedCANull()

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -1981,6 +1981,49 @@ class TestTruncatedHMACNotNull(unittest.TestCase):
                           b'\x0c'])
 
 
+class TestTruncatedHMACNotNull12(unittest.TestCase):
+    def test_test(self):
+        probe = TruncatedHMACNotNull12()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00X'
+                          b'\x01\x00\x00T'
+                          b'\x03\x03' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00&' +
+                          DEFAULT_12_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x05'
+                          b'\x00\x04\x00\x01'
+                          b'\x0c'])
+
+
+class TestTruncatedHMACNotNull12PFS(unittest.TestCase):
+    def test_test(self):
+        probe = TruncatedHMACNotNull12PFS()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.maxDiff = None
+        self.assertEqual(sock.sent_data,
+                         [b"\x16\x03\x01\x00\x90"
+                          b"\x01\x00\x00\x8c"
+                          b"\x03\x03" +
+                          RANDOM_STR +
+                          b"\x00"
+                          b"\x00^" +
+                          DEFAULT_PFS_CIPHERS_STR +
+                          b"\x01\x00"
+                          b'\x00\x05'
+                          b'\x00\x04\x00\x01'
+                          b'\x0c'])
+
+
 class TestOCSPNull(unittest.TestCase):
     def test_test(self):
         probe = OCSPNull()

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -1789,6 +1789,47 @@ class TestTrustedCANull(unittest.TestCase):
                           b'\x00\x03\x00\x00'])
 
 
+class TestTrustedCANull12(unittest.TestCase):
+    def test_test(self):
+        probe = TrustedCANull12()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00W'
+                          b'\x01\x00\x00S'
+                          b'\x03\x03' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00&' +
+                          DEFAULT_12_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x04'
+                          b'\x00\x03\x00\x00'])
+
+
+class TestTrustedCANull12PFS(unittest.TestCase):
+    def test_test(self):
+        probe = TrustedCANull12PFS()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.maxDiff = None
+        self.assertEqual(sock.sent_data,
+                         [b"\x16\x03\x01\x00\x8f"
+                          b"\x01\x00\x00\x8b"
+                          b"\x03\x03" +
+                          RANDOM_STR +
+                          b"\x00"
+                          b"\x00^" +
+                          DEFAULT_PFS_CIPHERS_STR +
+                          b"\x01\x00"
+                          b'\x00\x04'
+                          b'\x00\x03\x00\x00'])
+
+
 class TestTrustedCAOverflow(unittest.TestCase):
     def test_test(self):
         probe = TrustedCAOverflow()

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -1916,6 +1916,50 @@ class TestTrustedCAUnderflow(unittest.TestCase):
                           b'\x00\x15\x01' + 'a'*20 + b'\x00'])
 
 
+class TestTrustedCAUnderflow12(unittest.TestCase):
+    def test_test(self):
+        probe = TrustedCAUnderflow12()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.maxDiff = None
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00o'
+                          b'\x01\x00\x00k'
+                          b'\x03\x03' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00&' +
+                          DEFAULT_12_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x1c'
+                          b'\x00\x03\x00\x18'
+                          b'\x00\x15\x01' + 'a'*20 + b'\x00'])
+
+
+class TestTrustedCAUnderflow12PFS(unittest.TestCase):
+    def test_test(self):
+        probe = TrustedCAUnderflow12PFS()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.maxDiff = None
+        self.assertEqual(sock.sent_data,
+                         [b"\x16\x03\x01\x00\xa7"
+                          b"\x01\x00\x00\xa3"
+                          b"\x03\x03" +
+                          RANDOM_STR +
+                          b"\x00"
+                          b"\x00^" +
+                          DEFAULT_PFS_CIPHERS_STR +
+                          b"\x01\x00"
+                          b'\x00\x1c'
+                          b'\x00\x03\x00\x18'
+                          b'\x00\x15\x01' + 'a'*20 + b'\x00'])
+
+
 class TestTruncatedHMACNotNull(unittest.TestCase):
     def test_test(self):
         probe = TruncatedHMACNotNull()

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -2044,6 +2044,47 @@ class TestOCSPNull(unittest.TestCase):
                           b'\x00\x05\x00\x00'])
 
 
+class TestOCSPNull12(unittest.TestCase):
+    def test_test(self):
+        probe = OCSPNull12()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00W'
+                          b'\x01\x00\x00S'
+                          b'\x03\x03' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00&' +
+                          DEFAULT_12_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x04'
+                          b'\x00\x05\x00\x00'])
+
+
+class TestOCSPNull12PFS(unittest.TestCase):
+    def test_test(self):
+        probe = OCSPNull12PFS()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.maxDiff = None
+        self.assertEqual(sock.sent_data,
+                         [b"\x16\x03\x01\x00\x8f"
+                          b"\x01\x00\x00\x8b"
+                          b"\x03\x03" +
+                          RANDOM_STR +
+                          b"\x00"
+                          b"\x00^" +
+                          DEFAULT_PFS_CIPHERS_STR +
+                          b"\x01\x00"
+                          b'\x00\x04'
+                          b'\x00\x05\x00\x00'])
+
+
 class TestOCSPOverflow(unittest.TestCase):
     def test_test(self):
         probe = OCSPOverflow()

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -2106,6 +2106,49 @@ class TestOCSPOverflow(unittest.TestCase):
                           b'\x01\x00\x00\x00'])
 
 
+class TestOCSPOverflow12(unittest.TestCase):
+    def test_test(self):
+        probe = OCSPOverflow12()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00['
+                          b'\x01\x00\x00W'
+                          b'\x03\x03' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00&' +
+                          DEFAULT_12_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x08'
+                          b'\x00\x05\x00\x04'
+                          b'\x01\x00\x00\x00'])
+
+
+class TestOCSPOverflow12PFS(unittest.TestCase):
+    def test_test(self):
+        probe = OCSPOverflow12PFS()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.maxDiff = None
+        self.assertEqual(sock.sent_data,
+                         [b"\x16\x03\x01\x00\x93"
+                          b"\x01\x00\x00\x8f"
+                          b"\x03\x03" +
+                          RANDOM_STR +
+                          b"\x00"
+                          b"\x00^" +
+                          DEFAULT_PFS_CIPHERS_STR +
+                          b"\x01\x00"
+                          b'\x00\x08'
+                          b'\x00\x05\x00\x04'
+                          b'\x01\x00\x00\x00'])
+
+
 class TestOCSPUnderflow(unittest.TestCase):
     def test_test(self):
         probe = OCSPUnderflow()

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -1662,6 +1662,49 @@ class TestMaxFragmentInvalid(unittest.TestCase):
                           b'\x08'])
 
 
+class TestMaxFragmentInvalid12(unittest.TestCase):
+    def test_test(self):
+        probe = MaxFragmentInvalid12()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00X'
+                          b'\x01\x00\x00T'
+                          b'\x03\x03' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00&' +
+                          DEFAULT_12_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x05'
+                          b'\x00\x01\x00\x01'
+                          b'\x08'])
+
+
+class TestMaxFragmentInvalid12PFS(unittest.TestCase):
+    def test_test(self):
+        probe = MaxFragmentInvalid12PFS()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.maxDiff = None
+        self.assertEqual(sock.sent_data,
+                         [b"\x16\x03\x01\x00\x90"
+                          b"\x01\x00\x00\x8c"
+                          b"\x03\x03" +
+                          RANDOM_STR +
+                          b"\x00"
+                          b"\x00^" +
+                          DEFAULT_PFS_CIPHERS_STR +
+                          b"\x01\x00"
+                          b'\x00\x05'
+                          b'\x00\x01\x00\x01'
+                          b'\x08'])
+
+
 class TestClientCertURLsNotNull(unittest.TestCase):
     def test_test(self):
         probe = ClientCertURLsNotNull()

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -1600,6 +1600,47 @@ class TestMaxFragmentNull(unittest.TestCase):
                           b'\x00\x01\x00\x00'])
 
 
+class TestMaxFragmentNull12(unittest.TestCase):
+    def test_test(self):
+        probe = MaxFragmentNull12()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00W'
+                          b'\x01\x00\x00S'
+                          b'\x03\x03' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00&' +
+                          DEFAULT_12_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x04'
+                          b'\x00\x01\x00\x00'])
+
+
+class TestMaxFragmentNull12PFS(unittest.TestCase):
+    def test_test(self):
+        probe = MaxFragmentNull12PFS()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.maxDiff = None
+        self.assertEqual(sock.sent_data,
+                         [b"\x16\x03\x01\x00\x8f"
+                          b"\x01\x00\x00\x8b"
+                          b"\x03\x03" +
+                          RANDOM_STR +
+                          b"\x00"
+                          b"\x00^" +
+                          DEFAULT_PFS_CIPHERS_STR +
+                          b"\x01\x00"
+                          b'\x00\x04'
+                          b'\x00\x01\x00\x00'])
+
+
 class TestMaxFragmentInvalid(unittest.TestCase):
     def test_test(self):
         probe = MaxFragmentInvalid()

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -2236,3 +2236,50 @@ class TestDoubleExtension(unittest.TestCase):
                           b'\x00'
                           b'\xff\x01\x00\x01'
                           b'\x00'])
+
+
+class TestDoubleExtension12(unittest.TestCase):
+    def test_test(self):
+        probe = DoubleExtension12()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00]'
+                          b'\x01\x00\x00Y'
+                          b'\x03\x03' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00&' +
+                          DEFAULT_12_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x0a'
+                          b'\xff\x01\x00\x01'
+                          b'\x00'
+                          b'\xff\x01\x00\x01'
+                          b'\x00'])
+
+
+class TestDoubleExtension12PFS(unittest.TestCase):
+    def test_test(self):
+        probe = DoubleExtension12PFS()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.maxDiff = None
+        self.assertEqual(sock.sent_data,
+                         [b"\x16\x03\x01\x00\x95"
+                          b"\x01\x00\x00\x91"
+                          b"\x03\x03" +
+                          RANDOM_STR +
+                          b"\x00"
+                          b"\x00^" +
+                          DEFAULT_PFS_CIPHERS_STR +
+                          b"\x01\x00"
+                          b'\x00\x0a'
+                          b'\xff\x01\x00\x01'
+                          b'\x00'
+                          b'\xff\x01\x00\x01'
+                          b'\x00'])

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -2171,6 +2171,50 @@ class TestOCSPUnderflow(unittest.TestCase):
                           b'\x01\x00\x00\x00\x00\x00\x00'])
 
 
+class TestOCSPUnderflow12(unittest.TestCase):
+    def test_test(self):
+        probe = OCSPUnderflow12()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.maxDiff = None
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00^'
+                          b'\x01\x00\x00Z'
+                          b'\x03\x03' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00&' +
+                          DEFAULT_12_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x0b'
+                          b'\x00\x05\x00\x07'
+                          b'\x01\x00\x00\x00\x00\x00\x00'])
+
+
+class TestOCSPUnderflow12PFS(unittest.TestCase):
+    def test_test(self):
+        probe = OCSPUnderflow12PFS()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.maxDiff = None
+        self.assertEqual(sock.sent_data,
+                         [b"\x16\x03\x01\x00\x96"
+                          b"\x01\x00\x00\x92"
+                          b"\x03\x03" +
+                          RANDOM_STR +
+                          b"\x00"
+                          b"\x00^" +
+                          DEFAULT_PFS_CIPHERS_STR +
+                          b"\x01\x00"
+                          b'\x00\x0b'
+                          b'\x00\x05\x00\x07'
+                          b'\x01\x00\x00\x00\x00\x00\x00'])
+
+
 class TestDoubleExtension(unittest.TestCase):
     def test_test(self):
         probe = DoubleExtension()

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -1578,3 +1578,235 @@ class TestSecureRenegoNonEmpty12PFS(unittest.TestCase):
                           b'\x01\x00'
                           b'\x00\x04'
                           b'\xff\x01\x00\x00'])
+
+
+class TestMaxFragmentNull(unittest.TestCase):
+    def test_test(self):
+        probe = MaxFragmentNull()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00?'
+                          b'\x01\x00\x00;'
+                          b'\x03\x01' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00\x0e' +
+                          DEFAULT_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x04'
+                          b'\x00\x01\x00\x00'])
+
+
+class TestMaxFragmentInvalid(unittest.TestCase):
+    def test_test(self):
+        probe = MaxFragmentInvalid()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00@'
+                          b'\x01\x00\x00<'
+                          b'\x03\x01' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00\x0e' +
+                          DEFAULT_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x05'
+                          b'\x00\x01\x00\x01'
+                          b'\x08'])
+
+
+class TestClientCertURLsNotNull(unittest.TestCase):
+    def test_test(self):
+        probe = ClientCertURLsNotNull()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00A'
+                          b'\x01\x00\x00='
+                          b'\x03\x01' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00\x0e' +
+                          DEFAULT_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x06'
+                          b'\x00\x02\x00\x02'
+                          b'\x08\x00'])
+
+
+class TestTrustedCANull(unittest.TestCase):
+    def test_test(self):
+        probe = TrustedCANull()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00?'
+                          b'\x01\x00\x00;'
+                          b'\x03\x01' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00\x0e' +
+                          DEFAULT_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x04'
+                          b'\x00\x03\x00\x00'])
+
+
+class TestTrustedCAOverflow(unittest.TestCase):
+    def test_test(self):
+        probe = TrustedCAOverflow()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00A'
+                          b'\x01\x00\x00='
+                          b'\x03\x01' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00\x0e' +
+                          DEFAULT_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x06'
+                          b'\x00\x03\x00\x02'
+                          b'\x00\x15'])
+
+
+class TestTrustedCAUnderflow(unittest.TestCase):
+    def test_test(self):
+        probe = TrustedCAUnderflow()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.maxDiff = None
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00W'
+                          b'\x01\x00\x00S'
+                          b'\x03\x01' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00\x0e' +
+                          DEFAULT_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x1c'
+                          b'\x00\x03\x00\x18'
+                          b'\x00\x15\x01' + 'a'*20 + b'\x00'])
+
+
+class TestTruncatedHMACNotNull(unittest.TestCase):
+    def test_test(self):
+        probe = TruncatedHMACNotNull()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00@'
+                          b'\x01\x00\x00<'
+                          b'\x03\x01' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00\x0e' +
+                          DEFAULT_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x05'
+                          b'\x00\x04\x00\x01'
+                          b'\x0c'])
+
+
+class TestOCSPNull(unittest.TestCase):
+    def test_test(self):
+        probe = OCSPNull()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00?'
+                          b'\x01\x00\x00;'
+                          b'\x03\x01' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00\x0e' +
+                          DEFAULT_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x04'
+                          b'\x00\x05\x00\x00'])
+
+
+class TestOCSPOverflow(unittest.TestCase):
+    def test_test(self):
+        probe = OCSPOverflow()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00C'
+                          b'\x01\x00\x00?'
+                          b'\x03\x01' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00\x0e' +
+                          DEFAULT_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x08'
+                          b'\x00\x05\x00\x04'
+                          b'\x01\x00\x00\x00'])
+
+
+class TestOCSPUnderflow(unittest.TestCase):
+    def test_test(self):
+        probe = OCSPUnderflow()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.maxDiff = None
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00F'
+                          b'\x01\x00\x00B'
+                          b'\x03\x01' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00\x0e' +
+                          DEFAULT_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x0b'
+                          b'\x00\x05\x00\x07'
+                          b'\x01\x00\x00\x00\x00\x00\x00'])
+
+
+class TestDoubleExtension(unittest.TestCase):
+    def test_test(self):
+        probe = DoubleExtension()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00E'
+                          b'\x01\x00\x00A'
+                          b'\x03\x01' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00\x0e' +
+                          DEFAULT_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x0a'
+                          b'\xff\x01\x00\x01'
+                          b'\x00'
+                          b'\xff\x01\x00\x01'
+                          b'\x00'])

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -1851,6 +1851,49 @@ class TestTrustedCAOverflow(unittest.TestCase):
                           b'\x00\x15'])
 
 
+class TestTrustedCAOverflow12(unittest.TestCase):
+    def test_test(self):
+        probe = TrustedCAOverflow12()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.assertEqual(sock.sent_data,
+                         [b'\x16\x03\x01\x00Y'
+                          b'\x01\x00\x00U'
+                          b'\x03\x03' +
+                          RANDOM_STR +
+                          b'\x00'
+                          b'\x00&' +
+                          DEFAULT_12_CIPHERS_STR +
+                          b'\x01\x00'
+                          b'\x00\x06'
+                          b'\x00\x03\x00\x02'
+                          b'\x00\x15'])
+
+
+class TestTrustedCAOverflow12PFS(unittest.TestCase):
+    def test_test(self):
+        probe = TrustedCAOverflow12PFS()
+        sock = MockSock()
+
+        probe.test(sock)
+
+        self.maxDiff = None
+        self.assertEqual(sock.sent_data,
+                         [b"\x16\x03\x01\x00\x91"
+                          b"\x01\x00\x00\x8d"
+                          b"\x03\x03" +
+                          RANDOM_STR +
+                          b"\x00"
+                          b"\x00^" +
+                          DEFAULT_PFS_CIPHERS_STR +
+                          b"\x01\x00"
+                          b'\x00\x06'
+                          b'\x00\x03\x00\x02'
+                          b'\x00\x15'])
+
+
 class TestTrustedCAUnderflow(unittest.TestCase):
     def test_test(self):
         probe = TrustedCAUnderflow()


### PR DESCRIPTION
add tests to the RFC6066 probes, extend to TLSv1.2
